### PR TITLE
coverage tree model for go coverage profile

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -27,10 +27,11 @@ func NewGoCoverCommand() *cobra.Command {
 	o := NewDiffOptions()
 
 	cmd := &cobra.Command{
-		Use:     "gocover",
-		Short:   "Generate unit test diff coverage for go code",
-		Long:    getLong,
-		Example: getExample,
+		Use:          "gocover",
+		Short:        "Generate unit test diff coverage for go code",
+		Long:         getLong,
+		Example:      getExample,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Run(cmd, args); err != nil {
 				return fmt.Errorf("generate diff coverage %w", err)

--- a/pkg/report/diffcoverage_test.go
+++ b/pkg/report/diffcoverage_test.go
@@ -36,6 +36,7 @@ func TestDiffCoverage(t *testing.T) {
 	t.Run("GenerateDiffCoverage", func(t *testing.T) {
 		t.Run("generate percent coverage", func(t *testing.T) {
 			diff := &diffCoverage{
+				coverageTree:   NewCoverageTree(""),
 				comparedBranch: "origin/main",
 				profiles: []*cover.Profile{
 					{
@@ -275,6 +276,7 @@ func TestDiffCoverage(t *testing.T) {
 
 	t.Run("percentCovered", func(t *testing.T) {
 		diff := &diffCoverage{
+			coverageTree:   NewCoverageTree(""),
 			comparedBranch: "origin/main",
 			profiles: []*cover.Profile{
 				{

--- a/pkg/report/fullcoverage.go
+++ b/pkg/report/fullcoverage.go
@@ -8,7 +8,7 @@ import (
 )
 
 type FullCoverage interface {
-	BuildFullCoverageTree()
+	BuildFullCoverageTree() []*AllInformation
 }
 
 func NewFullCoverage(
@@ -34,7 +34,6 @@ func NewFullCoverage(
 			Root:           NewTreeNode(moduleHostPath, false),
 		},
 	}, nil
-
 }
 
 var _ FullCoverage = (*fullCoverage)(nil)
@@ -45,18 +44,10 @@ type fullCoverage struct {
 	coverageTree    CoverageTree
 }
 
-func (full *fullCoverage) BuildFullCoverageTree() {
+func (full *fullCoverage) BuildFullCoverageTree() []*AllInformation {
 	full.ignore()
 	full.covered()
-	all := full.coverageTree.All()
-	for _, v := range all {
-		fmt.Println(
-			v.Path,
-			v.TotalLines,
-			v.TotalCoveredLines,
-			fmt.Sprintf("%.2f %%", float64(v.TotalCoveredLines)/float64(v.TotalLines)*100),
-		)
-	}
+	return full.coverageTree.All()
 }
 
 func (full *fullCoverage) ignore() {

--- a/pkg/report/fullcoverage.go
+++ b/pkg/report/fullcoverage.go
@@ -1,0 +1,92 @@
+package report
+
+import (
+	"fmt"
+	"regexp"
+
+	"golang.org/x/tools/cover"
+)
+
+type FullCoverage interface {
+	BuildFullCoverageTree()
+}
+
+func NewFullCoverage(
+	profiles []*cover.Profile,
+	moduleHostPath string,
+	excludes []string,
+) (FullCoverage, error) {
+
+	var excludesRegexps []*regexp.Regexp
+	for _, ignorePattern := range excludes {
+		reg, err := regexp.Compile(ignorePattern)
+		if err != nil {
+			return nil, fmt.Errorf("compile pattern %s: %w", ignorePattern, err)
+		}
+		excludesRegexps = append(excludesRegexps, reg)
+	}
+
+	return &fullCoverage{
+		profiles:        profiles,
+		excludesRegexps: excludesRegexps,
+		coverageTree: &coverageTree{
+			ModuleHostPath: moduleHostPath,
+			Root:           NewTreeNode(moduleHostPath, false),
+		},
+	}, nil
+
+}
+
+var _ FullCoverage = (*fullCoverage)(nil)
+
+type fullCoverage struct {
+	profiles        []*cover.Profile
+	excludesRegexps []*regexp.Regexp
+	coverageTree    CoverageTree
+}
+
+func (full *fullCoverage) BuildFullCoverageTree() {
+	full.ignore()
+	full.covered()
+	all := full.coverageTree.All()
+	for _, v := range all {
+		fmt.Println(
+			v.Path,
+			v.TotalLines,
+			v.TotalCoveredLines,
+			fmt.Sprintf("%.2f %%", float64(v.TotalCoveredLines)/float64(v.TotalLines)*100),
+		)
+	}
+}
+
+func (full *fullCoverage) ignore() {
+	var filteredProfiles []*cover.Profile
+
+	for _, p := range full.profiles {
+		filter := false
+		for _, reg := range full.excludesRegexps {
+			if reg.MatchString(p.FileName) {
+				filter = true
+				break
+			}
+		}
+		if !filter {
+			filteredProfiles = append(filteredProfiles, p)
+		}
+	}
+
+	full.profiles = filteredProfiles
+}
+
+func (full *fullCoverage) covered() {
+	for _, p := range full.profiles {
+		node := full.coverageTree.FindOrCreate(p.FileName)
+		for _, b := range p.Blocks {
+			node.TotalLines += int64(b.NumStmt)
+			if b.Count > 0 {
+				node.TotalCoveredLines += int64(b.NumStmt)
+			}
+		}
+	}
+	full.coverageTree.CollectCoverageData()
+}

--- a/pkg/report/fullcoverage_test.go
+++ b/pkg/report/fullcoverage_test.go
@@ -1,0 +1,225 @@
+package report
+
+import (
+	"regexp"
+	"testing"
+
+	"golang.org/x/tools/cover"
+)
+
+func TestFullCoverage(t *testing.T) {
+	t.Run("NewFullCoverage", func(t *testing.T) {
+		_, err := NewFullCoverage([]*cover.Profile{}, "github.com/Azure/gocover", []string{"**"})
+		if err == nil {
+			t.Error("should return error")
+		}
+
+		diff, err := NewFullCoverage(
+			[]*cover.Profile{},
+			"github.com/Azure/gocover",
+			[]string{
+				".*github.com/Azure/gocover/report/tool.go",
+				"github.com/Azure/gocover/test/.*",
+				"github.com/Azure/gocover/mock_*",
+			})
+		if err != nil {
+			t.Errorf("should not return error: %s", err)
+		}
+		if diff == nil {
+			t.Error("should not nil")
+		}
+	})
+
+	t.Run("ignore", func(t *testing.T) {
+		t.Run("ignore files", func(t *testing.T) {
+			diff := &fullCoverage{
+				profiles: []*cover.Profile{
+					{
+						FileName: "github.com/Azure/gocover/report/tool.go",
+					},
+					{
+						FileName: "github.com/Azure/gocover/mock_interface/a.go",
+					},
+					{
+						FileName: "github.com/Azure/gocover/test/b.go",
+					},
+					{
+						FileName: "github.com/Azure/gocover/utils/common.go",
+					},
+				},
+			}
+
+			for _, p := range []string{
+				".*github.com/Azure/gocover/report/tool.go",
+				"github.com/Azure/gocover/test/.*",
+				"github.com/Azure/gocover/mock_*",
+			} {
+				reg := regexp.MustCompile(p)
+				diff.excludesRegexps = append(diff.excludesRegexps, reg)
+			}
+
+			diff.ignore()
+
+			if len(diff.profiles) != 1 {
+				t.Errorf("after ignore, should have 1 profile, but get: %d", len(diff.profiles))
+			}
+			if diff.profiles[0].FileName != "github.com/Azure/gocover/utils/common.go" {
+				t.Errorf("after ignore, only common.go is left, but get: %s", diff.profiles[0].FileName)
+			}
+		})
+	})
+
+	t.Run("covered", func(t *testing.T) {
+		full := &fullCoverage{
+			coverageTree: NewCoverageTree(""),
+			profiles: []*cover.Profile{
+				{
+					FileName: "github.com/Azure/gocover/report/utils.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/tool.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+						{
+							StartLine: 4,
+							EndLine:   6,
+							NumStmt:   3,
+							Count:     0,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/common.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+						{
+							StartLine: 4,
+							EndLine:   6,
+							NumStmt:   3,
+							Count:     0,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/rename.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/delete.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+			},
+		}
+
+		full.covered()
+	})
+
+	t.Run("BuildFullCoverageTree", func(t *testing.T) {
+		full := &fullCoverage{
+			coverageTree: NewCoverageTree(""),
+			profiles: []*cover.Profile{
+				{
+					FileName: "github.com/Azure/gocover/report/utils.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/tool.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+						{
+							StartLine: 4,
+							EndLine:   6,
+							NumStmt:   3,
+							Count:     0,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/common.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+						{
+							StartLine: 4,
+							EndLine:   6,
+							NumStmt:   3,
+							Count:     0,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/rename.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+				{
+					FileName: "github.com/Azure/gocover/report/delete.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
+			},
+		}
+		full.BuildFullCoverageTree()
+	})
+
+}

--- a/pkg/report/tree.go
+++ b/pkg/report/tree.go
@@ -1,0 +1,179 @@
+package report
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/cover"
+)
+
+const (
+	seperator = "/"
+)
+
+type CoverageTree interface {
+	// FindOrCreate returns the leaf node that represents the source file (go) if found,
+	// otherwise, it will creates the all the nodes along the path to the leaf, and finally return it.
+	FindOrCreate(file string) *TreeNode
+	Find(pkgPath string) *TreeNode
+	CollectCoverageData()
+	All() []*AllInformation
+}
+
+type Tree *TreeNode
+
+// TreeNode represents the node of multi branches tree.
+// Each node contains the basic coverage information,
+// includes covered lines count, totol lines count and vioaltion lines count.
+// Each internal node has one or many sub node, which is stored in a map, and can be retrieved by node name.
+// For the leaf node, it does not have sub node.
+type TreeNode struct {
+	Name                string               // name
+	TotalLines          int64                // total lines account for coverage
+	TotalCoveredLines   int64                // covered lines account for coverage
+	TotalViolationLines int64                // violation lines that not covered for coverage
+	Nodes               map[string]*TreeNode // sub nodes that store in map
+	isLeaf              bool                 // whether the node is leaf or internal node
+}
+
+func NewCoverageTree(hostpath string) CoverageTree {
+	return &coverageTree{
+		ModuleHostPath: hostpath,
+		Root:           NewTreeNode(hostpath, false),
+	}
+}
+
+func NewCoverageTreeFromProfiles(hostpath string, profiles []*cover.Profile) CoverageTree {
+	coverageTree := NewCoverageTree(hostpath)
+
+	for _, profile := range profiles {
+		node := coverageTree.FindOrCreate(profile.FileName)
+		for _, b := range profile.Blocks {
+			node.TotalLines += int64(b.NumStmt)
+			if b.Count > 0 {
+				node.TotalCoveredLines += int64(b.NumStmt)
+			}
+		}
+	}
+
+	coverageTree.CollectCoverageData()
+	return coverageTree
+}
+
+func NewTreeNode(name string, isLeaf bool) *TreeNode {
+	return &TreeNode{
+		Name:   name,
+		Nodes:  make(map[string]*TreeNode),
+		isLeaf: isLeaf,
+	}
+}
+
+type coverageTree struct {
+	ModuleHostPath string
+	Root           Tree
+}
+
+var _ CoverageTree = (*coverageTree)(nil)
+
+type AllInformation struct {
+	Path              string
+	TotalLines        int64
+	TotalCoveredLines int64
+}
+
+func (p *coverageTree) All() []*AllInformation {
+	var result []*AllInformation
+
+	var dfs func(root *TreeNode, contents []string)
+	dfs = func(root *TreeNode, contents []string) {
+		if root == nil {
+			return
+		}
+
+		fullpathname := strings.Join(append(contents, root.Name), seperator)
+		if p.ModuleHostPath == "" {
+			fullpathname = strings.TrimLeft(fullpathname, seperator)
+		}
+
+		result = append(result, &AllInformation{
+			Path:              fullpathname,
+			TotalLines:        root.TotalLines,
+			TotalCoveredLines: root.TotalCoveredLines,
+		})
+
+		for _, v := range root.Nodes {
+			dfs(v, append(contents, root.Name))
+		}
+
+	}
+
+	dfs(p.Root, []string{})
+	return result
+}
+
+func (p *coverageTree) Find(pkgPath string) *TreeNode {
+	trimed := strings.TrimPrefix(pkgPath, p.ModuleHostPath)
+	tokens := strings.Split(strings.Trim(trimed, seperator), seperator)
+
+	currentNode := p.Root
+	for _, name := range tokens {
+		if node, ok := currentNode.Nodes[name]; ok {
+			currentNode = node
+		} else {
+			return nil
+		}
+	}
+	return currentNode
+}
+
+func (p *coverageTree) FindOrCreate(file string) *TreeNode {
+	trimed := strings.TrimPrefix(file, p.ModuleHostPath)
+	dir, f := filepath.Split(trimed)
+	tokens := strings.Split(strings.Trim(dir, seperator), seperator)
+
+	currentNode := p.Root
+	for _, name := range tokens {
+		if node, ok := currentNode.Nodes[name]; ok {
+			currentNode = node
+		} else {
+			newNode := NewTreeNode(name, false)
+			currentNode.Nodes[name] = newNode
+			currentNode = newNode
+		}
+	}
+
+	leaf := NewTreeNode(f, true)
+	currentNode.Nodes[f] = leaf
+	return leaf
+}
+
+func (p *coverageTree) CollectCoverageData() {
+	collect(p.Root)
+}
+
+// collect collects coverage data bottom-up.
+// After collecting, the root node contains the whole coverage view of the go module,
+// and return three values: total, covered, violation.
+func collect(root *TreeNode) (int64, int64, int64) {
+	// when node is nil, return 0 for total, covered, and violation
+	if root == nil {
+		return 0, 0, 0
+	}
+
+	// iterates over each sub node, and collects all the total, covered, and violation to current node.
+	var total int64 = 0
+	var covered int64 = 0
+	var violation int64 = 0
+	for _, node := range root.Nodes {
+		t, c, v := collect(node)
+		total += t
+		covered += c
+		violation += v
+	}
+
+	root.TotalLines += total
+	root.TotalCoveredLines += covered
+	root.TotalViolationLines += violation
+
+	return root.TotalLines, root.TotalCoveredLines, root.TotalViolationLines
+}

--- a/pkg/report/tree_test.go
+++ b/pkg/report/tree_test.go
@@ -1,0 +1,184 @@
+package report
+
+import "testing"
+
+var root *TreeNode
+
+func beforeRun() {
+	// root
+	//    |-- child1
+	//    |   |-- leaf1
+	//    |   |-- child3
+	//    |       |-- leaf3
+	//    |-- child2
+	//        |-- leaf20
+	//        |-- leaf21
+	root = &TreeNode{
+		Name: "github.com/Azure/gocover",
+		Nodes: map[string]*TreeNode{
+			"child1": {
+				Name: "child1",
+				Nodes: map[string]*TreeNode{
+					"leaf1": {
+						Name:                "leaf1",
+						TotalLines:          100,
+						TotalCoveredLines:   80,
+						TotalViolationLines: 20,
+						isLeaf:              true,
+					},
+					"child3": {
+						Name: "child3",
+						Nodes: map[string]*TreeNode{
+							"leaf3": {
+								Name:                "leaf3",
+								TotalLines:          80,
+								TotalCoveredLines:   50,
+								TotalViolationLines: 30,
+								isLeaf:              true,
+							},
+						},
+					},
+				},
+			},
+			"child2": {
+				Name: "child2",
+				Nodes: map[string]*TreeNode{
+					"leaf20": {
+						Name:                "leaf20",
+						TotalLines:          50,
+						TotalCoveredLines:   40,
+						TotalViolationLines: 10,
+						isLeaf:              true,
+					},
+					"leaf21": {
+						Name:                "leaf21",
+						TotalLines:          60,
+						TotalCoveredLines:   30,
+						TotalViolationLines: 30,
+						isLeaf:              true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestCoverageTree(t *testing.T) {
+
+	t.Run("collect when root is nil", func(t *testing.T) {
+		var root *TreeNode
+		total, covered, violation := collect(root)
+		if total != 0 {
+			t.Errorf("total expected 0, but get %d", total)
+		}
+		if covered != 0 {
+			t.Errorf("covered expected 0, but get %d", covered)
+		}
+		if violation != 0 {
+			t.Errorf("violation expected 0, but get %d", violation)
+		}
+	})
+
+	t.Run("collect when root contains all the statistical data", func(t *testing.T) {
+		beforeRun()
+
+		total, covered, violation := collect(root)
+		if total != 290 {
+			t.Errorf("total expected 290, but get %d", total)
+		}
+		if covered != 200 {
+			t.Errorf("covered expected 200, but get %d", covered)
+		}
+		if violation != 90 {
+			t.Errorf("violation expected 90, but get %d", violation)
+		}
+	})
+
+	t.Run("FindOrCreate", func(t *testing.T) {
+		coverageTree := NewCoverageTree("github.com/Azure/gocover")
+		node := coverageTree.FindOrCreate("pkg/util/bar.go")
+		if node.Name != "bar.go" {
+			t.Errorf("expect name of leaf node bar.go, but get %s", node.Name)
+		}
+	})
+
+	// TODO: handle empty string
+	t.Run("FindOrCreate", func(t *testing.T) {
+		coverageTree := NewCoverageTree("github.com/Azure/gocover")
+		node := coverageTree.FindOrCreate("")
+		if node.Name != "" {
+			t.Errorf("expect name of leaf node bar.go, but get %s", node.Name)
+		}
+	})
+
+	t.Run("CollectCoverageData", func(t *testing.T) {
+		beforeRun()
+
+		coverageTree := &coverageTree{
+			ModuleHostPath: "github.com/Azure/gocover",
+			Root:           root,
+		}
+		coverageTree.CollectCoverageData()
+		if coverageTree.Root.TotalLines != 290 {
+			t.Errorf("total expected 290, but get %d", coverageTree.Root.TotalLines)
+		}
+		if coverageTree.Root.TotalCoveredLines != 200 {
+			t.Errorf("covered expected 200, but get %d", coverageTree.Root.TotalCoveredLines)
+		}
+		if coverageTree.Root.TotalViolationLines != 90 {
+			t.Errorf("violation expected 90, but get %d", coverageTree.Root.TotalViolationLines)
+		}
+	})
+
+	t.Run("All", func(t *testing.T) {
+		beforeRun()
+
+		coverageTree := &coverageTree{
+			ModuleHostPath: "github.com/Azure/gocover",
+			Root:           root,
+		}
+		coverageTree.CollectCoverageData()
+
+		all := coverageTree.All()
+		if len(all) != 8 {
+			t.Errorf("should have 8 items, but get %d", len(all))
+		}
+	})
+
+	t.Run("Find", func(t *testing.T) {
+		beforeRun()
+
+		coverageTree := &coverageTree{
+			ModuleHostPath: "github.com/Azure/gocover",
+			Root:           root,
+		}
+		coverageTree.CollectCoverageData()
+
+		node := coverageTree.Find("child1/leaf1")
+		if node == nil {
+			t.Errorf("shoud not return nil")
+		}
+		if node.isLeaf == false {
+			t.Errorf("leaf node")
+		}
+		if node.TotalLines != 100 {
+			t.Errorf("total should 100, but %d", node.TotalLines)
+		}
+
+		node = coverageTree.Find("child2")
+		if node == nil {
+			t.Errorf("shoud not return nil")
+		}
+		if node.isLeaf == true {
+			t.Errorf("internal node")
+		}
+		if node.TotalLines != 110 {
+			t.Errorf("total should 110, but %d", node.TotalLines)
+		}
+
+		node = coverageTree.Find("child3")
+		if node != nil {
+			t.Errorf("should return nil when not found")
+		}
+	})
+}

--- a/pkg/report/tree_test.go
+++ b/pkg/report/tree_test.go
@@ -133,13 +133,18 @@ func TestCoverageTree(t *testing.T) {
 	t.Run("All", func(t *testing.T) {
 		beforeRun()
 
-		coverageTree := &coverageTree{
-			ModuleHostPath: "github.com/Azure/gocover",
-			Root:           root,
+		coverageTree := &coverageTree{}
+		coverageTree.CollectCoverageData()
+		all := coverageTree.All()
+		if len(all) != 0 {
+			t.Errorf("should have 0 items, but get %d", len(all))
 		}
+
+		coverageTree.ModuleHostPath = ""
+		coverageTree.Root = root
 		coverageTree.CollectCoverageData()
 
-		all := coverageTree.All()
+		all = coverageTree.All()
 		if len(all) != 8 {
 			t.Errorf("should have 8 items, but get %d", len(all))
 		}


### PR DESCRIPTION
`ignore` step is the place that will exclude the files or code lines that does not account into the final coverage outcomes.
In the next month, July, we will improve it, and support add annotation to excludes codes apparently.
The draft idea is:
1. `// +ignore:all` ignore the whole file.
2. `// +ignore:line` ignore the next code line.
3. `// +ignore:multi` ignore the next code lines until meet a new empty line.

In the processing file step, we will take those annotation into account then and preprocessing file, then pass the results to the next calculation step.