### PR TITLE
check nil pointer for coverageProfile

### DIFF
--- a/pkg/report/diffcoverage.go
+++ b/pkg/report/diffcoverage.go
@@ -120,14 +120,15 @@ func (diff *diffCoverage) percentCovered() *Statistics {
 
 		case gittool.ModifyMode:
 
-			coverageProfile := generateCoverageProfileWithModifyMode(p, change)
-			coverageProfiles = append(coverageProfiles, coverageProfile)
+			if coverageProfile := generateCoverageProfileWithModifyMode(p, change); coverageProfile != nil {
+				coverageProfiles = append(coverageProfiles, coverageProfile)
 
-			node := diff.coverageTree.FindOrCreate(change.FileName)
-			node.TotalLines += int64(coverageProfile.TotalLines)
-			node.TotalCoveredLines += int64(coverageProfile.CoveredLines)
-			node.TotalViolationLines += int64(len(coverageProfile.TotalViolationLines))
-			node.CoverageProfile = coverageProfile
+				node := diff.coverageTree.FindOrCreate(change.FileName)
+				node.TotalLines += int64(coverageProfile.TotalLines)
+				node.TotalCoveredLines += int64(coverageProfile.CoveredLines)
+				node.TotalViolationLines += int64(len(coverageProfile.TotalViolationLines))
+				node.CoverageProfile = coverageProfile
+			}
 
 		case gittool.RenameMode:
 		case gittool.DeleteMode:


### PR DESCRIPTION
Check nil pointer first before using it although it should not happen.