### PR TITLE
add ignore annotation support

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -1,0 +1,199 @@
+package annotation
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	// IgnoreRegexp finds the gocover ignore pattern.
+	// Three kind ignore pattern are supported:
+	//   //+gocover:ignore:all
+	//   //+gocover:ignore:block
+	//   //+gocover:ignore:{number}
+	//
+	// - `//+gocover:ignore:all`
+	//   will ignore the whole file, the file won't be used to calculate coverage.
+	//
+	// - `//+gocover:ignore:block`
+	//   will ignore a code block, the code block won't be used to calculate coverage.
+	//   code block is the code that have many non-blank lines until it meet a blank line.
+	//   for example:
+	//       pf, err := os.Open(fileName)  -|
+	//       if err != nil {                |
+	// 	         return nil, err            | -> code block
+	//       }                              |
+	//       defer pf.Close()              -|
+	//
+	//       profile, err := parseIgnoreProfilesFromReader(pf) -|
+	//       profile.Filename = fileName                        | -> code block
+	//       return profile, err                               -|
+	//
+	// - `//+gocover:ignore:{number}`
+	//    will ignore the specific code lines, and the code won't be used to calculate coverage.
+	//    for example:
+	//       //+gocover:ignore:5
+	//       pf, err := os.Open(fileName)  -|
+	//       if err != nil {                |
+	// 	         return nil, err            | -> these 5 lines will be ignored
+	//       }                              |
+	//       defer pf.Close()              -|
+	//
+	//       profile, err := parseIgnoreProfilesFromReader(pf) -|
+	//       profile.Filename = fileName                        | -> code block
+	//       return profile, err                               -|
+	//
+	// Question: how to ignore the whole go function?
+	IgnoreRegexp = regexp.MustCompile(`^\s*//\s*\+gocover:ignore:([0-9A-Za-z]+)`)
+)
+
+// IgnoreType indicates the type of the ignore profile.
+// - ALL_IGNORE means the profile ignore the whole input file.
+// - BLOCK_IGNORE means the profile ignore several code block of the input file.
+type IgnoreType string
+
+const (
+	ALL_IGNORE   IgnoreType = "all"
+	BLOCK_IGNORE IgnoreType = "block"
+)
+
+// IgnoreProfile represents the ignore profiling data for a specific file.
+type IgnoreProfile struct {
+	// type of the ignore profile.
+	// when it's BLOCK_IGNORE, Lines includes all the code line number that should be ignored,
+	// IgnoreBlocks contains the concrete ignore data.
+	Type         IgnoreType
+	Filename     string
+	Lines        map[int]bool
+	IgnoreBlocks []*IgnoreBlock
+}
+
+// IgnoreBlock represents a single block of ignore profiling data.
+type IgnoreBlock struct {
+	Annotation string   // concrete ignore pattern
+	Contents   []string // ignore contents
+	Lines      []int    // corresponding code line number of the ignore contents
+}
+
+// ParseIgnoreProfiles parses ignore profile data in the specified file and returns a ignore profile.
+func ParseIgnoreProfiles(fileName string) (*IgnoreProfile, error) {
+	pf, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer pf.Close()
+
+	profile, err := parseIgnoreProfilesFromReader(pf)
+	profile.Filename = fileName
+	return profile, err
+}
+
+// parseIgnoreProfilesFromReader parses ignore profile data from the Reader and returns a ignore profile.
+func parseIgnoreProfilesFromReader(rd io.Reader) (*IgnoreProfile, error) {
+	s := bufio.NewScanner(rd)
+	lineNo := 0
+
+	profile := &IgnoreProfile{
+		Lines: make(map[int]bool),
+		Type:  BLOCK_IGNORE,
+	}
+
+	for s.Scan() {
+		lineNo++
+		line := s.Text()
+		match := IgnoreRegexp.FindStringSubmatch(line)
+
+		// not match, continue next line
+		if match == nil {
+			continue
+		}
+		if len(match) < 2 {
+			continue
+		}
+
+		// match contains the result of the regexp on IgnoreRegexp
+		// match = ["//+gocover:ignore:all", "all"] when input is `//+gocover:ignore:all`,
+		// match = ["//+gocover:ignore:block", "block"] when input is `//+gocover:ignore:block`,
+		// match = ["//+gocover:ignore:10", "10"] when input is `//+gocover:ignore:10`,
+		ignoreKind := match[1]
+		if ignoreKind == "all" { // set type to ALL_IGNORE and skip further processing
+			profile.Type = ALL_IGNORE
+			break
+		} else if ignoreKind == "block" { // block
+			skipLineCnt := ignoreOnBlock(s, profile, lineNo, line)
+			lineNo += skipLineCnt
+		} else { // number
+			// parse number fail means it's not the supported pattern, continue next line
+			total, err := strconv.Atoi(ignoreKind)
+			if err != nil {
+				continue
+			}
+			skipLineCnt := ignoreOnNumber(s, profile, lineNo, total, line)
+			lineNo += skipLineCnt
+		}
+	}
+
+	return profile, nil
+}
+
+// ignoreOnBlock process pattern that ignore on code block.
+// proccessing until a blank line.
+func ignoreOnBlock(scanner *bufio.Scanner, profile *IgnoreProfile, startLine int, patternText string) int {
+	block := &IgnoreBlock{Annotation: patternText}
+	skipLines := 0
+	total := 0
+
+	var content string
+	for scanner.Scan() {
+		skipLines++
+		content = scanner.Text()
+		if strings.TrimSpace(content) == "" {
+			break
+		}
+
+		startLine++
+		total++
+		block.Lines = append(block.Lines, startLine)
+		block.Contents = append(block.Contents, content)
+		profile.Lines[startLine] = true
+	}
+
+	if total != 0 {
+		profile.IgnoreBlocks = append(profile.IgnoreBlocks, block)
+	}
+	return skipLines
+}
+
+// ignoreOnNumber process pattern that ignore specific lines.
+func ignoreOnNumber(scanner *bufio.Scanner, profile *IgnoreProfile, startLine, cnt int, patternText string) int {
+	if cnt <= 0 {
+		return 0
+	}
+
+	block := &IgnoreBlock{Annotation: patternText}
+	skipLines := 0
+
+	var content string
+	for cnt > 0 {
+		if !scanner.Scan() {
+			break
+		}
+		cnt--
+		startLine++
+		skipLines++
+		content = scanner.Text()
+
+		block.Lines = append(block.Lines, startLine)
+		block.Contents = append(block.Contents, content)
+		profile.Lines[startLine] = true
+	}
+
+	if skipLines != 0 {
+		profile.IgnoreBlocks = append(profile.IgnoreBlocks, block)
+	}
+	return skipLines
+}

--- a/pkg/annotation/annotation_test.go
+++ b/pkg/annotation/annotation_test.go
@@ -1,0 +1,509 @@
+package annotation
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIgnoreRegexp(t *testing.T) {
+	t.Run("validate IgnoreRegexp", func(t *testing.T) {
+		var testSuites = []struct {
+			input  string
+			expect []string
+		}{
+			{input: "//+gocover:ignore:all", expect: []string{"//+gocover:ignore:all", "all"}},
+			{input: "// +gocover:ignore:all", expect: []string{"// +gocover:ignore:all", "all"}},
+			{input: "    //+gocover:ignore:all", expect: []string{"    //+gocover:ignore:all", "all"}},
+			{input: "//+gocover:ignore:block", expect: []string{"//+gocover:ignore:block", "block"}},
+			{input: "// +gocover:ignore:block", expect: []string{"// +gocover:ignore:block", "block"}},
+			{input: "    //+gocover:ignore:block", expect: []string{"    //+gocover:ignore:block", "block"}},
+			{input: "  //  //+gocover:ignore:blcok", expect: []string{}},
+		}
+
+		for _, testSuite := range testSuites {
+			match := IgnoreRegexp.FindStringSubmatch(testSuite.input)
+			if len(match) != len(testSuite.expect) {
+				t.Errorf("expect %d items, but get %d", len(testSuite.expect), len(match))
+			}
+			n := len(match)
+			for i := 0; i < n; i++ {
+				if match[i] != testSuite.expect[i] {
+					t.Errorf("expect item %d %s, but %s", i, testSuite.expect[i], match[i])
+				}
+			}
+		}
+	})
+}
+
+func TestParseIgnoreProfiles(t *testing.T) {
+	t.Run("read file error", func(t *testing.T) {
+		_, err := ParseIgnoreProfiles("/nonexist")
+		if err == nil {
+			t.Errorf("should return error, but return nil")
+		}
+	})
+
+	t.Run("ignore all", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "foo.go")
+		lines := []string{
+			`    //+gocover:ignore:all`,
+			`    package foo`,
+			`    func foo() {`,
+			`         fmt.Println("foo")`,
+			`    }`,
+		}
+		input := strings.Join(lines, "\n")
+		ioutil.WriteFile(f, []byte(input), 0666)
+
+		profile, err := ParseIgnoreProfiles(f)
+		if err != nil {
+			t.Errorf("should return nil, but get: %s", err)
+		}
+
+		if profile.Filename != f {
+			t.Errorf("filename should %s, but get %s", f, profile.Filename)
+		}
+		if profile.Type != ALL_IGNORE {
+			t.Errorf("type should %s, but %s", ALL_IGNORE, profile.Type)
+		}
+	})
+
+	t.Run("ignore block", func(t *testing.T) {
+		dir := t.TempDir()
+		f := filepath.Join(dir, "foo.go")
+		lines := []string{
+			`    //+gocover:ignore:block`,
+			`    package foo`,
+			`    func foo() {`,
+			`         fmt.Println("foo")`,
+			`    }`,
+		}
+		input := strings.Join(lines, "\n")
+		ioutil.WriteFile(f, []byte(input), 0666)
+
+		profile, err := ParseIgnoreProfiles(f)
+		if err != nil {
+			t.Errorf("should return nil, but get: %s", err)
+		}
+
+		if profile.Filename != f {
+			t.Errorf("filename should %s, but get %s", f, profile.Filename)
+		}
+		if profile.Type != BLOCK_IGNORE {
+			t.Errorf("type should %s, but %s", BLOCK_IGNORE, profile.Type)
+		}
+		for idx := 0; idx < 4; idx++ {
+			if _, ok := profile.Lines[idx+2]; !ok {
+				t.Errorf("should contains %d", idx+2)
+			}
+		}
+	})
+}
+
+func TestParseIgnoreProfilesFromReader(t *testing.T) {
+
+	t.Run("ignore all", func(t *testing.T) {
+		lines := []string{
+			`    //+gocover:ignore:all`,
+			`    a := "Hello world"`,
+			`    fmt.Println(a)`,
+			``,
+			`    b := "Go"`,
+			`    fmt.Println(b)`,
+		}
+		input := strings.Join(lines, "\n")
+		r := bytes.NewReader([]byte(input))
+
+		profile, err := parseIgnoreProfilesFromReader(r)
+		if err != nil {
+			t.Errorf("should not error, but %s", err)
+		}
+		if profile.Type != ALL_IGNORE {
+			t.Errorf("type should %s, but %s", ALL_IGNORE, profile.Type)
+		}
+	})
+
+	t.Run("ignore block", func(t *testing.T) {
+		ignorePattern := `    //+gocover:ignore:block`
+		lines := []string{
+			ignorePattern,
+			`    a := "Hello world"`,
+			`    fmt.Println(a)`,
+			``,
+			`    b := "Go"`,
+			`    fmt.Println(b)`,
+		}
+		input := strings.Join(lines, "\n")
+		r := bytes.NewReader([]byte(input))
+
+		profile, err := parseIgnoreProfilesFromReader(r)
+		if err != nil {
+			t.Errorf("should not error, but %s", err)
+		}
+		if profile.Type != BLOCK_IGNORE {
+			t.Errorf("type should %s, but %s", BLOCK_IGNORE, profile.Type)
+		}
+		if len(profile.IgnoreBlocks) != 1 {
+			t.Errorf("should have 1 ignore block, but get %d", len(profile.IgnoreBlocks))
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern, block.Annotation)
+		}
+		for idx := 0; idx < 2; idx++ {
+			if block.Lines[idx] != idx+2 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+1] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+	})
+
+	t.Run("ignore range", func(t *testing.T) {
+		ignorePattern := `    //+gocover:ignore:4`
+		lines := []string{
+			ignorePattern,
+			`    a := "Hello world"`,
+			`    fmt.Println(a)`,
+			``,
+			`    b := "Go"`,
+			`    fmt.Println(b)`,
+		}
+		input := strings.Join(lines, "\n")
+		r := bytes.NewReader([]byte(input))
+
+		profile, err := parseIgnoreProfilesFromReader(r)
+		if err != nil {
+			t.Errorf("should not error, but %s", err)
+		}
+		if profile.Type != BLOCK_IGNORE {
+			t.Errorf("type should %s, but %s", BLOCK_IGNORE, profile.Type)
+		}
+		if len(profile.IgnoreBlocks) != 1 {
+			t.Errorf("should have 1 ignore block, but get %d", len(profile.IgnoreBlocks))
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern, block.Annotation)
+		}
+		for idx := 0; idx < 4; idx++ {
+			if block.Lines[idx] != idx+2 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+1] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+	})
+
+	t.Run("ignore block and range", func(t *testing.T) {
+		ignorePattern1 := `    //+gocover:ignore:block`
+		ignorePattern2 := `    //+gocover:ignore:1`
+		lines := []string{
+			ignorePattern1,
+			`    a := "Hello world"`,
+			`    fmt.Println(a)`,
+			``,
+			ignorePattern2,
+			`    invokeFoo(a)`,
+			`    invokeBar(a)`,
+		}
+		input := strings.Join(lines, "\n")
+		r := bytes.NewReader([]byte(input))
+
+		profile, err := parseIgnoreProfilesFromReader(r)
+		if err != nil {
+			t.Errorf("should not error, but %s", err)
+		}
+		if profile.Type != BLOCK_IGNORE {
+			t.Errorf("type should %s, but %s", BLOCK_IGNORE, profile.Type)
+		}
+		if len(profile.IgnoreBlocks) != 2 {
+			t.Errorf("should have 2 ignore blocks, but get %d", len(profile.IgnoreBlocks))
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern1 {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern1, block.Annotation)
+		}
+		for idx := 0; idx < 2; idx++ {
+			if block.Lines[idx] != idx+2 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+1] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+
+		block = profile.IgnoreBlocks[1]
+		if block.Annotation != ignorePattern2 {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern2, block.Annotation)
+		}
+		for idx := 0; idx < 1; idx++ {
+			if block.Lines[idx] != idx+6 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+5] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+	})
+
+	t.Run("ignore range and block", func(t *testing.T) {
+		ignorePattern1 := `    //+gocover:ignore:2`
+		ignorePattern2 := `    //+gocover:ignore:block`
+		lines := []string{
+			ignorePattern1,
+			`    a := "Hello world"`,
+			`    fmt.Println(a)`,
+			``,
+			ignorePattern2,
+			`    invokeFoo(a)`,
+			`    invokeBar(a)`,
+		}
+		input := strings.Join(lines, "\n")
+		r := bytes.NewReader([]byte(input))
+
+		profile, err := parseIgnoreProfilesFromReader(r)
+		if err != nil {
+			t.Errorf("should not error, but %s", err)
+		}
+		if profile.Type != BLOCK_IGNORE {
+			t.Errorf("type should %s, but %s", BLOCK_IGNORE, profile.Type)
+		}
+		if len(profile.IgnoreBlocks) != 2 {
+			t.Errorf("should have 2 ignore blocks, but get %d", len(profile.IgnoreBlocks))
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern1 {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern1, block.Annotation)
+		}
+		for idx := 0; idx < 2; idx++ {
+			if block.Lines[idx] != idx+2 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+1] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+
+		block = profile.IgnoreBlocks[1]
+		if block.Annotation != ignorePattern2 {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern2, block.Annotation)
+		}
+		for idx := 0; idx < 2; idx++ {
+			if block.Lines[idx] != idx+6 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx+5] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+	})
+}
+
+func TestIgnoreOnblock(t *testing.T) {
+	lines := []string{
+		`    a := "Hello world"`,
+		`    fmt.Println(a)`,
+		``,
+		`    b := "Go"`,
+		`    fmt.Println(b)`,
+	}
+	input := strings.Join(lines, "\n")
+
+	t.Run("input is not empty", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(input)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignorePattern := "//+gocover:ignore:block"
+
+		skipLines := ignoreOnBlock(scanner, profile, 0, ignorePattern)
+		if skipLines != 3 {
+			t.Errorf("should skip 3 lines, but get: %d", skipLines)
+		}
+		if len(profile.IgnoreBlocks) == 0 {
+			t.Errorf("should have at least ignore blocks, but get 0")
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern, block.Annotation)
+		}
+		for idx := 0; idx < 2; idx++ {
+			if block.Lines[idx] != idx+1 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+
+		for idx := 0; idx < 2; idx++ {
+			if _, ok := profile.Lines[idx+1]; !ok {
+				t.Errorf("should contains %d", idx+1)
+			}
+		}
+	})
+
+	t.Run("input is empty", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(`  `)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignorePattern := "//+gocover:ignore:block"
+
+		skipLines := ignoreOnBlock(scanner, profile, 0, ignorePattern)
+		if skipLines != 1 {
+			t.Errorf("should skip 1 line, but get: %d", skipLines)
+		}
+		if len(profile.IgnoreBlocks) != 0 {
+			t.Errorf("should have no ignore blocks, but get %d", len(profile.IgnoreBlocks))
+		}
+	})
+}
+
+func TestIgnoreOnNumber(t *testing.T) {
+	// input has 5 lines
+	lines := []string{
+		`    a := "Hello world"`,
+		`    fmt.Println(a)`,
+		``,
+		`    b := "Go"`,
+		`    fmt.Println(b)`,
+	}
+	input := strings.Join(lines, "\n")
+
+	t.Run("when require skip number is less than total lines of input", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(input)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignoreLines := 4
+		ignorePattern := "//+gocover:ignore:4"
+		skipLines := ignoreOnNumber(scanner, profile, 0, ignoreLines, ignorePattern)
+
+		if skipLines != ignoreLines {
+			t.Errorf("should ignore %d lines, but get: %d", ignoreLines, skipLines)
+		}
+		if len(profile.IgnoreBlocks) == 0 {
+			t.Errorf("should have at least ignore blocks, but get 0")
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern, block.Annotation)
+		}
+		for idx := 0; idx < ignoreLines; idx++ {
+			if block.Lines[idx] != idx+1 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+
+		for idx := 0; idx < 4; idx++ {
+			if _, ok := profile.Lines[idx+1]; !ok {
+				t.Errorf("should contains %d", idx+1)
+			}
+		}
+	})
+
+	t.Run("when require number is greater than total lines of input", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(input)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignoreLines := 6
+		ignorePattern := "//+gocover:ignore:6"
+		skipLines := ignoreOnNumber(scanner, profile, 0, ignoreLines, ignorePattern)
+
+		if skipLines != len(lines) {
+			t.Errorf("should ignore %d lines, but get: %d", len(lines), skipLines)
+		}
+		if len(profile.IgnoreBlocks) == 0 {
+			t.Errorf("should have at least ignore blocks, but get 0")
+		}
+
+		block := profile.IgnoreBlocks[0]
+		if block.Annotation != ignorePattern {
+			t.Errorf("ignore pattern should be %s, but %s", ignorePattern, block.Annotation)
+		}
+		for idx := 0; idx < len(lines); idx++ {
+			if block.Lines[idx] != idx+1 {
+				t.Errorf("line %d should be ignored, but %d", idx+1, block.Lines[idx])
+			}
+			if block.Contents[idx] != lines[idx] {
+				t.Errorf("line (%s) should be ignored, but (%s)", lines[idx], block.Contents[idx])
+			}
+		}
+
+		for idx := 0; idx < len(lines); idx++ {
+			if _, ok := profile.Lines[idx+1]; !ok {
+				t.Errorf("should contains %d", idx+1)
+			}
+		}
+	})
+
+	t.Run("when require number is 0", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(input)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignoreLines := 0
+		ignorePattern := "//+gocover:ignore:0"
+		skipLines := ignoreOnNumber(scanner, profile, 0, ignoreLines, ignorePattern)
+		if skipLines != 0 {
+			t.Errorf("no line should be ignored, but get: %d", skipLines)
+		}
+		if len(profile.IgnoreBlocks) != 0 {
+			t.Errorf("should have no ignore blocks, but get %d", len(profile.IgnoreBlocks))
+		}
+	})
+
+	t.Run("input is empty", func(t *testing.T) {
+		scanner := bufio.NewScanner(bytes.NewReader([]byte(``)))
+
+		profile := &IgnoreProfile{
+			Lines: make(map[int]bool),
+			Type:  BLOCK_IGNORE,
+		}
+
+		ignoreLines := 4
+		ignorePattern := "//+gocover:ignore:4"
+		skipLines := ignoreOnNumber(scanner, profile, 0, ignoreLines, ignorePattern)
+
+		if skipLines != 0 {
+			t.Errorf("no line should be ignored, but get: %d", skipLines)
+		}
+		if len(profile.IgnoreBlocks) != 0 {
+			t.Errorf("should have no ignore blocks, but get %d", len(profile.IgnoreBlocks))
+		}
+	})
+}

--- a/pkg/annotation/doc.go
+++ b/pkg/annotation/doc.go
@@ -1,5 +1,23 @@
 // Package annotation provides the utils for filtering.
-// //+gocover:ignore:all
-// //+gocover:ignore:block
-// //+gocover:ignore:number
+//
+// There are two kinds of ignore.
+// 1. Ignore the whole go file.
+//    `//+gocover:ignore:file`
+// 2. Ignore a go code block.
+//    `//+gocover:ignore:block`
+//
+//   Code block concept comes from the go coverage profile, the detail can be found at
+//   https://cs.opensource.google/go/x/tools/+/master:cover/profile.go;drc=81efdbcac4736176ac97c60577b0069f76414c44;l=28
+//   https://go.dev/ref/spec#Blocks gives more details about it.
+//   For example:
+//       pf, err := os.Open(fileName)
+//       if err != nil {               -|
+// 	         return nil, err            | -> code block
+//       }                             -|
+//
+//       {
+//           fmt.Println()                                      -|
+//           profile, err := parseIgnoreProfilesFromReader(pf)   | -> code block
+//           profile.Filename = fileName                        -|
+//       }
 package annotation

--- a/pkg/annotation/doc.go
+++ b/pkg/annotation/doc.go
@@ -1,0 +1,5 @@
+// Package annotation provides the utils for filtering.
+// //+gocover:ignore:all
+// //+gocover:ignore:block
+// //+gocover:ignore:number
+package annotation

--- a/pkg/cmd/diffoptions.go
+++ b/pkg/cmd/diffoptions.go
@@ -54,7 +54,7 @@ func (o *DiffOptions) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("git diff: %w", err)
 	}
 
-	diffCoverage, err := report.NewDiffCoverage(profiles, changes, o.Excludes, o.CompareBranch)
+	diffCoverage, err := report.NewDiffCoverage(profiles, changes, o.Excludes, o.CompareBranch, o.RepositoryPath)
 	if err != nil {
 		return fmt.Errorf("new diff converage: %w", err)
 	}

--- a/pkg/report/diffcoverage.go
+++ b/pkg/report/diffcoverage.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -34,23 +35,13 @@ func NewDiffCoverage(
 		excludesRegexps = append(excludesRegexps, reg)
 	}
 
-	ignoreProfiles := make(map[string]*annotation.IgnoreProfile)
-	for _, c := range changes {
-		ignoreProfile, err := annotation.ParseIgnoreProfiles(filepath.Join(repositoryPath, c.FileName))
-		if err == nil {
-			ignoreProfiles[c.FileName] = ignoreProfile
-		} else {
-			fmt.Printf("warn: %s\n", err)
-		}
-	}
-
 	return &diffCoverage{
 		comparedBranch:  comparedBranch,
 		profiles:        profiles,
 		changes:         changes,
 		excludesRegexps: excludesRegexps,
 		coverageTree:    NewCoverageTree(""),
-		ignoreProfiles:  ignoreProfiles,
+		repositoryPath:  repositoryPath,
 	}, nil
 
 }
@@ -64,13 +55,16 @@ type diffCoverage struct {
 	profiles        []*cover.Profile  // go unit test coverage profiles
 	changes         []*gittool.Change // diff change between compared branch and HEAD commit
 	excludesRegexps []*regexp.Regexp  // excludes files regexp patterns
+	repositoryPath  string
 	ignoreProfiles  map[string]*annotation.IgnoreProfile
+	coverProfiles   map[string]*cover.Profile
 	coverageTree    CoverageTree
 }
 
 func (diff *diffCoverage) GenerateDiffCoverage() (*Statistics, error) {
 	diff.ignore()
 	diff.filter()
+	diff.generateIgnoreProfile()
 	return diff.percentCovered(), nil
 }
 
@@ -108,6 +102,47 @@ func (diff *diffCoverage) filter() {
 	diff.profiles = filterProfiles
 }
 
+func (diff *diffCoverage) generateIgnoreProfile() {
+	ignoreProfiles := make(map[string]*annotation.IgnoreProfile)
+	coverProfiles := make(map[string]*cover.Profile)
+
+	for _, c := range diff.changes {
+		p := findCoverProfile(c, diff.profiles)
+		if p == nil {
+			continue
+		}
+
+		sort.Sort(blocksByStart(p.Blocks))
+		coverProfiles[c.FileName] = p
+
+		ignoreProfile, err := annotation.ParseIgnoreProfiles(filepath.Join(diff.repositoryPath, c.FileName), p)
+		if err == nil {
+			ignoreProfiles[c.FileName] = ignoreProfile
+			for _, b := range ignoreProfile.IgnoreBlocks {
+				fmt.Fprintln(os.Stdout, b.Annotation)
+				for i := 0; i < len(b.Contents); i++ {
+					fmt.Fprintf(os.Stdout, "%d %s\n", b.Lines[i], b.Contents[i])
+				}
+			}
+		} else {
+			fmt.Println(err)
+		}
+	}
+
+	diff.ignoreProfiles = ignoreProfiles
+	diff.coverProfiles = coverProfiles
+}
+
+// findCoverProfile find the expected cover profile by file name.
+func findCoverProfile(change *gittool.Change, profiles []*cover.Profile) *cover.Profile {
+	for _, profile := range profiles {
+		if isSubFolderTo(profile.FileName, change.FileName) {
+			return profile
+		}
+	}
+	return nil
+}
+
 // percentCovered generate diff coverage profile
 // using go unit test covreage profile and diff changes between two commits.
 func (diff *diffCoverage) percentCovered() *Statistics {
@@ -121,14 +156,14 @@ func (diff *diffCoverage) percentCovered() *Statistics {
 		}
 
 		ignoreProfile, ok := diff.ignoreProfiles[change.FileName]
-		if ok && ignoreProfile.Type == annotation.ALL_IGNORE {
+		if ok && ignoreProfile.Type == annotation.FILE_IGNORE {
 			continue
 		}
 
 		switch change.Mode {
 		case gittool.NewMode:
 
-			if coverageProfile := generateCoverageProfileWithNewMode(p, change); coverageProfile != nil {
+			if coverageProfile := generateCoverageProfileWithNewMode(p, change, ignoreProfile); coverageProfile != nil {
 				coverageProfiles = append(coverageProfiles, coverageProfile)
 
 				node := diff.coverageTree.FindOrCreate(change.FileName)
@@ -140,7 +175,7 @@ func (diff *diffCoverage) percentCovered() *Statistics {
 
 		case gittool.ModifyMode:
 
-			if coverageProfile := generateCoverageProfileWithModifyMode(p, change); coverageProfile != nil {
+			if coverageProfile := generateCoverageProfileWithModifyMode(p, change, ignoreProfile); coverageProfile != nil {
 				coverageProfiles = append(coverageProfiles, coverageProfile)
 
 				node := diff.coverageTree.FindOrCreate(change.FileName)
@@ -169,21 +204,28 @@ func (diff *diffCoverage) percentCovered() *Statistics {
 }
 
 // generateCoverageProfileWithNewMode generates for new file
-func generateCoverageProfileWithNewMode(profile *cover.Profile, change *gittool.Change) *CoverageProfile {
+func generateCoverageProfileWithNewMode(profile *cover.Profile, change *gittool.Change, ignoreProfile *annotation.IgnoreProfile) *CoverageProfile {
 	var total, covered int64
 
 	sort.Sort(blocksByStart(profile.Blocks))
 
 	violationsMap := make(map[int]bool)
 	// NumStmt indicates the number of statements in a code block, it does not means the line, because a statement may have several lines,
-	// which means that the value of NumStmt is less or equal tothe total numbers of the code block.
+	// which means that the value of NumStmt is less or equal to the total numbers of the code block.
 	for _, b := range profile.Blocks {
-		total += int64(b.NumStmt)
-		if b.Count > 0 {
-			covered += int64(b.NumStmt)
-		} else {
-			for i := b.StartLine; i <= b.EndLine; i++ {
-				violationsMap[i] = true
+
+		for lineNo := b.StartLine; lineNo <= b.EndLine; lineNo++ {
+			if ignoreProfile != nil {
+				if _, ok := ignoreProfile.Lines[lineNo]; ok {
+					continue
+				}
+			}
+
+			total++
+			if b.Count > 0 {
+				covered++
+			} else {
+				violationsMap[lineNo] = true
 			}
 		}
 	}
@@ -214,7 +256,7 @@ func generateCoverageProfileWithNewMode(profile *cover.Profile, change *gittool.
 }
 
 // generateCoverageProfileWithModifyMode generates for modify file
-func generateCoverageProfileWithModifyMode(profile *cover.Profile, change *gittool.Change) *CoverageProfile {
+func generateCoverageProfileWithModifyMode(profile *cover.Profile, change *gittool.Change, ignoreProfile *annotation.IgnoreProfile) *CoverageProfile {
 
 	sort.Sort(blocksByStart(profile.Blocks))
 
@@ -227,6 +269,13 @@ func generateCoverageProfileWithModifyMode(profile *cover.Profile, change *gitto
 
 		var violationLines []int
 		for lineNo := section.StartLine; lineNo <= section.EndLine; lineNo++ {
+
+			// this line is ignored in annotation
+			if ignoreProfile != nil {
+				if _, ok := ignoreProfile.Lines[lineNo]; ok {
+					continue
+				}
+			}
 
 			block := findProfileBlock(profile.Blocks, lineNo)
 			if block == nil {

--- a/pkg/report/diffcoverage_test.go
+++ b/pkg/report/diffcoverage_test.go
@@ -1,11 +1,14 @@
 package report
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/Azure/gocover/pkg/annotation"
 	"github.com/Azure/gocover/pkg/gittool"
 	"golang.org/x/tools/cover"
 )
@@ -346,6 +349,17 @@ func TestDiffCoverage(t *testing.T) {
 						},
 					},
 				},
+				{
+					FileName: "github.com/Azure/gocover/report/ignore.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 1,
+							EndLine:   3,
+							NumStmt:   3,
+							Count:     1,
+						},
+					},
+				},
 			},
 			changes: []*gittool.Change{
 				{
@@ -414,6 +428,22 @@ func TestDiffCoverage(t *testing.T) {
 						},
 					},
 				},
+				{
+					FileName: "report/ignore.go",
+					Mode:     gittool.DeleteMode,
+					Sections: []*gittool.Section{
+						{
+							Operation: gittool.Add,
+							Count:     3,
+							StartLine: 4,
+							EndLine:   6,
+							Contents:  []string{"line4", "line5", "line6"},
+						},
+					},
+				},
+			},
+			ignoreProfiles: map[string]*annotation.IgnoreProfile{
+				"report/ignore.go": {Type: annotation.FILE_IGNORE},
 			},
 		}
 
@@ -437,6 +467,36 @@ func TestDiffCoverage(t *testing.T) {
 				t.Errorf("should have 2 coverage profile, but get: %d", len(statistics.CoverageProfile))
 			}
 		}
+	})
+
+	t.Run("generateIgnoreProfile", func(t *testing.T) {
+		tempDir := t.TempDir()
+		_ = ioutil.WriteFile(filepath.Join(tempDir, "foo.go"), []byte(`
+		//+gocover:ignore:block
+		if err != nil {
+			return err
+		}`), 0644)
+
+		diff := &diffCoverage{
+			repositoryPath: tempDir,
+			changes: []*gittool.Change{
+				{FileName: "foo.go"},
+				{FileName: "bar.go"},
+			},
+			profiles: []*cover.Profile{
+				{
+					FileName: "github.com/Azure/gocover/foo.go",
+					Blocks: []cover.ProfileBlock{
+						{
+							StartLine: 3,
+							EndLine:   5,
+						},
+					},
+				},
+			},
+		}
+
+		diff.generateIgnoreProfile()
 	})
 }
 
@@ -484,10 +544,20 @@ func TestGenerateCoverageProfileWithModifyMode(t *testing.T) {
 					EndLine:   9,
 					Contents:  []string{"line7", "line8", "line9"},
 				},
+				{
+					Operation: gittool.Add,
+					Count:     3,
+					StartLine: 10,
+					EndLine:   12,
+					Contents:  []string{"line10", "line11", "line12"},
+				},
 			},
 		}
 
-		coverageProfile := generateCoverageProfileWithModifyMode(profile, change)
+		coverageProfile := generateCoverageProfileWithModifyMode(profile, change, &annotation.IgnoreProfile{
+			Type:  annotation.BLOCK_IGNORE,
+			Lines: map[int]bool{10: true, 11: true, 12: true},
+		})
 		if coverageProfile.FileName != "report/tool.go" {
 			t.Errorf("expect filename %s, but get %s", "report/tool.go", coverageProfile.FileName)
 		}
@@ -530,7 +600,7 @@ func TestGenerateCoverageProfileWithModifyMode(t *testing.T) {
 			Sections: []*gittool.Section{},
 		}
 
-		coverageProfile := generateCoverageProfileWithModifyMode(profile, change)
+		coverageProfile := generateCoverageProfileWithModifyMode(profile, change, nil)
 		if coverageProfile != nil {
 			t.Error("should return nil when no lines in the profile")
 		}
@@ -554,6 +624,12 @@ func TestGenerateCoverageProfileWithNewMode(t *testing.T) {
 					NumStmt:   3,
 					Count:     0,
 				},
+				{
+					StartLine: 7,
+					EndLine:   10,
+					NumStmt:   3,
+					Count:     0,
+				},
 			},
 		}
 		change := &gittool.Change{
@@ -570,7 +646,10 @@ func TestGenerateCoverageProfileWithNewMode(t *testing.T) {
 			},
 		}
 
-		coverageProfile := generateCoverageProfileWithNewMode(profile, change)
+		coverageProfile := generateCoverageProfileWithNewMode(profile, change, &annotation.IgnoreProfile{
+			Type:  annotation.BLOCK_IGNORE,
+			Lines: map[int]bool{7: true, 8: true, 9: true, 10: true},
+		})
 		if coverageProfile.FileName != "report/tool.go" {
 			t.Errorf("expect filename %s, but get %s", "report/tool.go", coverageProfile.FileName)
 		}
@@ -613,9 +692,45 @@ func TestGenerateCoverageProfileWithNewMode(t *testing.T) {
 			Sections: []*gittool.Section{},
 		}
 
-		coverageProfile := generateCoverageProfileWithNewMode(profile, change)
+		coverageProfile := generateCoverageProfileWithNewMode(profile, change, nil)
 		if coverageProfile != nil {
 			t.Error("should return nil when no lines in the profile")
+		}
+	})
+}
+
+func TestFindCoverProfile(t *testing.T) {
+	t.Run("find cover profile", func(t *testing.T) {
+		profiles := []*cover.Profile{
+			{
+				FileName: "github.com/Azure/gocover/report/tool.go",
+			},
+		}
+		change := &gittool.Change{
+			FileName: "report/tool.go",
+			Mode:     gittool.NewMode,
+		}
+
+		profile := findCoverProfile(change, profiles)
+		if profile == nil {
+			t.Errorf("profile should not be nil")
+		}
+	})
+
+	t.Run("cannot find cover profile", func(t *testing.T) {
+		profiles := []*cover.Profile{
+			{
+				FileName: "github.com/Azure/gocover/report/tool.go",
+			},
+		}
+		change := &gittool.Change{
+			FileName: "report/foo.go",
+			Mode:     gittool.NewMode,
+		}
+
+		profile := findCoverProfile(change, profiles)
+		if profile != nil {
+			t.Errorf("profile should be nil")
 		}
 	})
 }

--- a/pkg/report/diffcoverage_test.go
+++ b/pkg/report/diffcoverage_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDiffCoverage(t *testing.T) {
 	t.Run("NewDiffCoverage", func(t *testing.T) {
-		_, err := NewDiffCoverage([]*cover.Profile{}, []*gittool.Change{}, []string{"**"}, "testbranch")
+		_, err := NewDiffCoverage([]*cover.Profile{}, []*gittool.Change{}, []string{"**"}, "testbranch", "")
 		if err == nil {
 			t.Error("should return error")
 		}
@@ -24,7 +24,7 @@ func TestDiffCoverage(t *testing.T) {
 				".*github.com/Azure/gocover/report/tool.go",
 				"github.com/Azure/gocover/test/.*",
 				"github.com/Azure/gocover/mock_*",
-			}, "testbranch")
+			}, "testbranch", "")
 		if err != nil {
 			t.Errorf("should not return error: %s", err)
 		}


### PR DESCRIPTION
Add ignore annotation support which support three kinds of ignore: ignore the whole file, ignore code block and ignore specific lines:
//+gocover:ignore:file
//+gocover:ignore:block

Use them in the code, will ignoring them when calculating the coverage.
Note that, `//+gocover:ignore:file` has the <b>highest priority</b>, it will overrides other blocks if they're both set.

- `//+gocover:ignore:file`
        will ignore the whole file, the file won't be used to calculate coverage.
        for example:
```
        //+gocover:ignore:file
        package foo
        func foo() {
        }
```
	
The whole file of this file will be ignored.

- `//+gocover:ignore:block`
	will ignore a code block, the code block won't be used to calculate coverage.
	code block can be refered to https://go.dev/ref/spec#Blocks for more information.
	for example:
```
        pf, err := os.Open(fileName)
        if err != nil {               -|
	         return nil, err       | -> code block
        }                             -|
        
        {
	        fmt.Println()                                      -|
	        profile, err := parseIgnoreProfilesFromReader(pf)   | -> code block
	        profile.Filename = fileName                        -|
        }
```

Before change, if we have a err check block that would fail the required coverage, for example 80%,
```
121	if err != nil {
122		fmt.Println()
123		fmt.Println()
124		fmt.Println()
125		fmt.Println()
126	}

./gocover --cover-profile coverage.out --compare-branch origin/main
Error: generate diff coverage total coverage pass rate is: 78.83
```

When using the ignore annotation, it can ignore those blocks and pass the required coverage.
```
121     //+gocover:ignore:block
122	if err != nil {
123		fmt.Println()
124		fmt.Println()
125		fmt.Println()
126		fmt.Println()
127	}

./gocover --cover-profile coverage.out --compare-branch origin/main
        //+gocover:ignore:block
122     if err != nil {
123             fmt.Println()
124             fmt.Println()
125             fmt.Println()
126             fmt.Println()
127     }
```