### PR TITLE
fix cannot find nested ignore blocks

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -124,19 +124,18 @@ func ignoreOnBlock(fileLines []string, profile *IgnoreProfile, coverProfile *cov
 		return patternLineNumber + 1
 	}
 
-	ignoreBlock := &IgnoreBlock{Annotation: patternText}
-
-	// Record the ignore code profile contents
-	for i := profileBlock.StartLine; i <= profileBlock.EndLine; i++ {
-		// as the source file of the scanner is same with cover profile,
-		// so this method call always true.
-		ignoreBlock.Lines = append(ignoreBlock.Lines, i)
-		ignoreBlock.Contents = append(ignoreBlock.Contents, fileLines[i-1])
-	}
-
 	if _, ok := profile.IgnoreBlocks[*profileBlock]; !ok {
+		ignoreBlock := &IgnoreBlock{Annotation: patternText}
+
+		// Record the ignore code profile contents
+		for i := profileBlock.StartLine; i <= profileBlock.EndLine; i++ {
+			// as the source file of the scanner is same with cover profile,
+			// so this method call always true.
+			ignoreBlock.Lines = append(ignoreBlock.Lines, i)
+			ignoreBlock.Contents = append(ignoreBlock.Contents, fileLines[i-1])
+		}
 		profile.IgnoreBlocks[*profileBlock] = ignoreBlock
 	}
 
-	return profileBlock.EndLine
+	return profileBlock.EndLine - 1
 }

--- a/pkg/report/diffcoverage_test.go
+++ b/pkg/report/diffcoverage_test.go
@@ -885,3 +885,32 @@ func TestFindProfileBlock(t *testing.T) {
 	})
 
 }
+
+func TestCheckTestFileExistence(t *testing.T) {
+	t.Run("no test files", func(t *testing.T) {
+		dir := t.TempDir()
+		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
+
+		exist, err := checkTestFileExistence(dir)
+		if err != nil {
+			t.Errorf("should not err, but get: %s", err)
+		}
+		if exist == true {
+			t.Errorf("should no test files, but exist")
+		}
+	})
+
+	t.Run("has test files", func(t *testing.T) {
+		dir := t.TempDir()
+		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
+		ioutil.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(""), 0644)
+
+		exist, err := checkTestFileExistence(dir)
+		if err != nil {
+			t.Errorf("should not err, but get: %s", err)
+		}
+		if exist == false {
+			t.Errorf("should have test files, but does not")
+		}
+	})
+}


### PR DESCRIPTION
```
L20 func case3(x int) { //+gocover:ignore:block
L21	var c, python, java = true, false, "yes!"
L22	if x > 0 { //+gocover:ignore:block
L23		fmt.Println(i, j, c, python, java)
L24	}
L25	fmt.Println(i, j, c, python, java, x)
L26}
```

For such nested case, it cannot ignore the statements in the `if` block, because two cover profile blocks from the `go test`may have start line and endline overlap. For example:
```
// github.com/Azure/gocover/pkg/report/util.go:20.19,22.11 2 0
// github.com/Azure/gocover/pkg/report/util.go:22.11,24.3 1 0
```

As array starts from 0, and profile block line counts from 1, so the return value of endline should be minus 1 to reflect it.