### PR TITLE
add "gocover test" command to check preconditions

### DIFF
--- a/pkg/gtest/gocovertest.go
+++ b/pkg/gtest/gocovertest.go
@@ -1,0 +1,4 @@
+package gtest
+
+type GocoverTest struct {
+}

--- a/pkg/gtest/gocovertest.go
+++ b/pkg/gtest/gocovertest.go
@@ -1,4 +1,137 @@
 package gtest
 
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/gocover/pkg/gittool"
+)
+
+const testFileSuffix = "_test.go"
+
 type GocoverTest struct {
+	RepositoryPath string
+	CompareBranch  string
+	GitClient      gittool.GitClient
+	Writer         io.Writer
+}
+
+func NewGocoverTest(
+	repositoryPath string,
+	compareBranch string,
+	writer io.Writer,
+) (*GocoverTest, error) {
+
+	gitClient, err := gittool.NewGitClient(repositoryPath)
+	if err != nil {
+		return nil, fmt.Errorf("git repository: %w", err)
+	}
+
+	return &GocoverTest{
+		RepositoryPath: repositoryPath,
+		CompareBranch:  compareBranch,
+		GitClient:      gitClient,
+		Writer:         writer,
+	}, nil
+}
+
+func (g *GocoverTest) CheckGoTestFiles() error {
+	changes, err := g.GitClient.DiffChangesFromCommitted(g.CompareBranch)
+	if err != nil {
+		return fmt.Errorf("git diff: %w", err)
+	}
+
+	handled := make(map[string]bool)
+	for _, c := range changes {
+		f := filepath.Join(g.RepositoryPath, c.FileName)
+
+		folder := filepath.Dir(f)
+		if _, ok := handled[folder]; ok {
+			continue
+		}
+		handled[folder] = true
+
+		fmt.Fprintf(g.Writer, "checking test files for package: %s\n", folder)
+
+		exist, err := checkTestFileExistence(folder)
+		if err != nil {
+			return fmt.Errorf("check test file existence: %w", err)
+		}
+		if exist {
+			continue
+		}
+
+		pkgName, err := parsePackageName(f)
+		if err != nil {
+			return fmt.Errorf("parse package name from %s: %w", f, err)
+		}
+
+		testFile := filepath.Join(folder, testFileName(pkgName))
+		ioutil.WriteFile(
+			testFile,
+			testFileContents(pkgName),
+			0644,
+		)
+		fmt.Fprintf(g.Writer, "no test files in package %s, create test file for it: %s\n", folder, testFile)
+	}
+
+	return nil
+}
+
+func testFileName(pkgName string) string {
+	return fmt.Sprintf("%s_test.go", pkgName)
+}
+
+func testFileContents(pkgName string) []byte {
+	return []byte(fmt.Sprintf("package %s", pkgName))
+}
+
+func checkTestFileExistence(folder string) (bool, error) {
+	files, err := ioutil.ReadDir(folder)
+	if err != nil {
+		return false, fmt.Errorf("%w", err)
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(strings.ToLower(f.Name()), testFileSuffix) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+var (
+	ErrPackageNameNotFound = errors.New("package not found")
+	packageRegexp          = regexp.MustCompile(`^package\s+([a-zA-Z][a-zA-Z0-9]*)`) // regexp for matching "package xxx"
+)
+
+func parsePackageName(filename string) (string, error) {
+	rd, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer rd.Close()
+
+	s := bufio.NewScanner(rd)
+	for s.Scan() {
+		match := packageRegexp.FindStringSubmatch(s.Text())
+		if match == nil {
+			continue
+		}
+
+		return match[1], nil
+	}
+
+	return "", ErrPackageNameNotFound
 }

--- a/pkg/gtest/gtest_test.go
+++ b/pkg/gtest/gtest_test.go
@@ -1,0 +1,217 @@
+package gtest
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/gocover/pkg/gittool"
+)
+
+func TestCheckGoTestFiles(t *testing.T) {
+	t.Run("diff changes failed", func(t *testing.T) {
+		dir := t.TempDir()
+		gocoverTest := &GocoverTest{
+			RepositoryPath: dir,
+			CompareBranch:  "origin/master",
+			Writer:         &bytes.Buffer{},
+			GitClient: &mockGitClient{
+				DiffChangesFromCommittedFn: func(compareBranch string) ([]*gittool.Change, error) {
+					return nil, errors.New("get changes error")
+				},
+			},
+		}
+
+		err := gocoverTest.CheckGoTestFiles()
+		if err == nil {
+			t.Errorf("should fail, but get nil")
+		}
+	})
+
+	t.Run("check go test files", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Mkdir(filepath.Join(dir, "foo"), 0777)
+		ioutil.WriteFile(filepath.Join(dir, "foo/foo.go"), []byte("package foo"), 0644)
+		ioutil.WriteFile(filepath.Join(dir, "foo/foo_test.go"), []byte("package foo"), 0644)
+
+		os.Mkdir(filepath.Join(dir, "bar"), 0777)
+		ioutil.WriteFile(filepath.Join(dir, "bar/bar.go"), []byte("package zoo"), 0644)
+
+		gocoverTest := &GocoverTest{
+			RepositoryPath: dir,
+			CompareBranch:  "origin/master",
+			Writer:         &bytes.Buffer{},
+			GitClient: &mockGitClient{
+				DiffChangesFromCommittedFn: func(compareBranch string) ([]*gittool.Change, error) {
+					return []*gittool.Change{
+						{FileName: "foo/foo.go"},
+						{FileName: "bar/bar.go"},
+					}, nil
+				},
+			},
+		}
+
+		err := gocoverTest.CheckGoTestFiles()
+		if err != nil {
+			t.Errorf("should no error, but get error %s", err)
+		}
+
+		newTestFile := filepath.Join(dir, "bar/zoo_test.go")
+		contents, err := ioutil.ReadFile(newTestFile)
+		if err != nil {
+			t.Errorf("should no error, but get error %s", err)
+		}
+		if string(contents) != "package zoo" {
+			t.Errorf("package contents should 'package bar', but get '%s'", string(contents))
+		}
+	})
+}
+
+type mockGitClient struct {
+	DiffChangesFromCommittedFn func(compareBranch string) ([]*gittool.Change, error)
+}
+
+func (gitClient *mockGitClient) DiffChangesFromCommitted(compareBranch string) ([]*gittool.Change, error) {
+	return gitClient.DiffChangesFromCommittedFn(compareBranch)
+}
+
+func TestCheckTestFileExistence(t *testing.T) {
+	t.Run("no test files", func(t *testing.T) {
+		dir := t.TempDir()
+		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
+
+		exist, err := checkTestFileExistence(dir)
+		if err != nil {
+			t.Errorf("should not err, but get: %s", err)
+		}
+		if exist == true {
+			t.Errorf("should no test files, but exist")
+		}
+	})
+
+	t.Run("has test files", func(t *testing.T) {
+		dir := t.TempDir()
+
+		os.Mkdir(filepath.Join(dir, "gocover"), 0777)
+		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
+		ioutil.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(""), 0644)
+
+		exist, err := checkTestFileExistence(dir)
+		if err != nil {
+			t.Errorf("should not err, but get: %s", err)
+		}
+		if exist == false {
+			t.Errorf("should have test files, but does not")
+		}
+	})
+}
+
+func TestTestfileName(t *testing.T) {
+	t.Run("testFileName", func(t *testing.T) {
+		testSuites := []struct {
+			input  string
+			expect string
+		}{
+			{input: "foo", expect: "foo_test.go"},
+			{input: "bar", expect: "bar_test.go"},
+			{input: "zoo", expect: "zoo_test.go"},
+		}
+
+		for _, testCase := range testSuites {
+			actual := testFileName(testCase.input)
+			if actual != testCase.expect {
+				t.Errorf("expect %s, but get %s", testCase.expect, actual)
+			}
+		}
+	})
+}
+
+func TestTestFileContents(t *testing.T) {
+	t.Run("testFileContents", func(t *testing.T) {
+		testSuites := []struct {
+			input  string
+			expect string
+		}{
+			{input: "foo", expect: "package foo"},
+			{input: "bar", expect: "package bar"},
+			{input: "zoo", expect: "package zoo"},
+		}
+
+		for _, testCase := range testSuites {
+			actual := testFileContents(testCase.input)
+			if string(actual) != testCase.expect {
+				t.Errorf("expect %s, but get %s", testCase.expect, string(actual))
+			}
+		}
+	})
+}
+
+func TestParsePackageName(t *testing.T) {
+	t.Run("package name found", func(t *testing.T) {
+		dir := t.TempDir()
+
+		fileContents := `// package zoo ...
+package zoo
+
+func foo() int { return 1 }
+	`
+		f := filepath.Join(dir, "foo.go")
+		ioutil.WriteFile(f, []byte(fileContents), 0644)
+
+		pkgName, err := parsePackageName(f)
+		if err != nil {
+			t.Errorf("should not error, but get %s", err)
+		}
+		if pkgName != "zoo" {
+			t.Errorf("package name should be zoo, but get %s", pkgName)
+		}
+	})
+
+	t.Run("no package name found", func(t *testing.T) {
+		dir := t.TempDir()
+
+		fileContents := `// package zoo ...
+func foo() int { return 1 }
+	`
+		f := filepath.Join(dir, "foo.go")
+		ioutil.WriteFile(f, []byte(fileContents), 0644)
+
+		_, err := parsePackageName(f)
+		if err == nil {
+			t.Errorf("should return error, but get nil")
+		}
+	})
+}
+
+func TestPackageRegexp(t *testing.T) {
+	t.Run("validate packageRegexp", func(t *testing.T) {
+		testSuite := []struct {
+			input  string
+			expect []string
+		}{
+			{input: "package foo", expect: []string{"package foo", "foo"}},
+			{input: "package foo", expect: []string{"package foo", "foo"}},
+			{input: "package  foo", expect: []string{"package  foo", "foo"}},
+			{input: "package foo1", expect: []string{"package foo1", "foo1"}},
+			{input: "package Foo1", expect: []string{"package Foo1", "Foo1"}},
+			{input: "package 1foo1", expect: nil},
+			{input: " package foo", expect: nil},
+		}
+
+		for _, testCase := range testSuite {
+			match := packageRegexp.FindStringSubmatch(testCase.input)
+			if len(match) != len(testCase.expect) {
+				t.Errorf("expect %d items, but get %d", len(testCase.expect), len(match))
+			}
+			n := len(match)
+			for i := 0; i < n; i++ {
+				if match[i] != testCase.expect[i] {
+					t.Errorf("expect item %d %s, but %s", i, testCase.expect[i], match[i])
+				}
+			}
+		}
+	})
+}

--- a/pkg/report/diffcoverage.go
+++ b/pkg/report/diffcoverage.go
@@ -3,7 +3,6 @@ package report
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -37,17 +36,6 @@ func NewDiffCoverage(
 			return nil, fmt.Errorf("compile pattern %s: %w", ignorePattern, err)
 		}
 		excludesRegexps = append(excludesRegexps, reg)
-	}
-
-	for _, c := range changes {
-		folder := filepath.Dir(filepath.Join(repositoryPath, c.FileName))
-		exist, err := checkTestFileExistence(folder)
-		if err != nil {
-			return nil, fmt.Errorf("checkTestFileExistence: %w", err)
-		}
-		if !exist {
-			return nil, fmt.Errorf("%w in %s", ErrNoTestFile, folder)
-		}
 	}
 
 	return &diffCoverage{
@@ -392,25 +380,6 @@ func findProfileBlock(blocks []cover.ProfileBlock, lineNumber int, line string) 
 		idx--
 	}
 	return nil
-}
-
-func checkTestFileExistence(folder string) (bool, error) {
-	files, err := ioutil.ReadDir(folder)
-	if err != nil {
-		return false, fmt.Errorf("%w", err)
-	}
-
-	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-
-		if strings.HasSuffix(strings.ToLower(f.Name()), "_test.go") {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 // findChange find the expected change by file name.

--- a/pkg/report/diffcoverage_test.go
+++ b/pkg/report/diffcoverage_test.go
@@ -885,32 +885,3 @@ func TestFindProfileBlock(t *testing.T) {
 	})
 
 }
-
-func TestCheckTestFileExistence(t *testing.T) {
-	t.Run("no test files", func(t *testing.T) {
-		dir := t.TempDir()
-		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
-
-		exist, err := checkTestFileExistence(dir)
-		if err != nil {
-			t.Errorf("should not err, but get: %s", err)
-		}
-		if exist == true {
-			t.Errorf("should no test files, but exist")
-		}
-	})
-
-	t.Run("has test files", func(t *testing.T) {
-		dir := t.TempDir()
-		ioutil.WriteFile(filepath.Join(dir, "foo.go"), []byte(""), 0644)
-		ioutil.WriteFile(filepath.Join(dir, "foo_test.go"), []byte(""), 0644)
-
-		exist, err := checkTestFileExistence(dir)
-		if err != nil {
-			t.Errorf("should not err, but get: %s", err)
-		}
-		if exist == false {
-			t.Errorf("should have test files, but does not")
-		}
-	})
-}


### PR DESCRIPTION
Add `gocover test` command for preparing integrating `go test` into gocover framework. Right now, it just checks the go test file existence and create an empty go test file if needed.