### PR TITLE
Fix in case of other files, not go files

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -225,7 +225,7 @@ func newTestCommand() *cobra.Command {
 				return fmt.Errorf("new gocover test: %s", err)
 			}
 
-			err = gocoverTest.CheckGoTestFiles()
+			err = gocoverTest.EnsureGoTestFiles()
 			if err != nil {
 				return fmt.Errorf("check go test files: %s", err)
 			}

--- a/pkg/gtest/gocovertest.go
+++ b/pkg/gtest/gocovertest.go
@@ -50,6 +50,11 @@ func (g *GocoverTest) CheckGoTestFiles() error {
 
 	handled := make(map[string]bool)
 	for _, c := range changes {
+		// in case of other files, except go files
+		if strings.HasSuffix(c.FileName, ".go") {
+			continue
+		}
+
 		f := filepath.Join(g.RepositoryPath, c.FileName)
 
 		folder := filepath.Dir(f)

--- a/pkg/gtest/gocovertest.go
+++ b/pkg/gtest/gocovertest.go
@@ -42,7 +42,9 @@ func NewGocoverTest(
 	}, nil
 }
 
-func (g *GocoverTest) CheckGoTestFiles() error {
+// EnsureGoTestFiles checks the diff changes, and ensures the existence of go test file
+// if there are changes about go source files.
+func (g *GocoverTest) EnsureGoTestFiles() error {
 	changes, err := g.GitClient.DiffChangesFromCommitted(g.CompareBranch)
 	if err != nil {
 		return fmt.Errorf("git diff: %w", err)
@@ -51,7 +53,7 @@ func (g *GocoverTest) CheckGoTestFiles() error {
 	handled := make(map[string]bool)
 	for _, c := range changes {
 		// in case of other files, except go files
-		if strings.HasSuffix(c.FileName, ".go") {
+		if !strings.HasSuffix(c.FileName, ".go") {
 			continue
 		}
 

--- a/pkg/gtest/gtest_test.go
+++ b/pkg/gtest/gtest_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/gocover/pkg/gittool"
 )
 
-func TestCheckGoTestFiles(t *testing.T) {
+func TestEnsureGoTestFiles(t *testing.T) {
 	t.Run("diff changes failed", func(t *testing.T) {
 		dir := t.TempDir()
 		gocoverTest := &GocoverTest{
@@ -25,7 +25,7 @@ func TestCheckGoTestFiles(t *testing.T) {
 			},
 		}
 
-		err := gocoverTest.CheckGoTestFiles()
+		err := gocoverTest.EnsureGoTestFiles()
 		if err == nil {
 			t.Errorf("should fail, but get nil")
 		}
@@ -43,7 +43,8 @@ func TestCheckGoTestFiles(t *testing.T) {
 		gocoverTest := &GocoverTest{
 			RepositoryPath: dir,
 			CompareBranch:  "origin/master",
-			Writer:         &bytes.Buffer{},
+			Writer:         os.Stdout,
+			// Writer:         &bytes.Buffer{},
 			GitClient: &mockGitClient{
 				DiffChangesFromCommittedFn: func(compareBranch string) ([]*gittool.Change, error) {
 					return []*gittool.Change{
@@ -54,7 +55,7 @@ func TestCheckGoTestFiles(t *testing.T) {
 			},
 		}
 
-		err := gocoverTest.CheckGoTestFiles()
+		err := gocoverTest.EnsureGoTestFiles()
 		if err != nil {
 			t.Errorf("should no error, but get error %s", err)
 		}


### PR DESCRIPTION
Result of diff commits may contain changes that not related to go files, so should filter them.