### PR TITLE
add parser to parse cover profile into statement using AST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/alecthomas/chroma/v2 v2.0.0-alpha4
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/tools v0.1.10
 )
@@ -41,6 +42,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -119,6 +120,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=

--- a/pkg/parser/doc.go
+++ b/pkg/parser/doc.go
@@ -1,0 +1,4 @@
+// Package parser parses the cover profiles into statements.
+//
+// Ref: https://github.com/axw/gocov
+package parser

--- a/pkg/parser/packages.go
+++ b/pkg/parser/packages.go
@@ -1,0 +1,207 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+)
+
+type Package struct {
+	// Name is the canonical path of the package.
+	Name string
+
+	// Functions is a list of functions registered with this package.
+	Functions []*Function
+}
+
+type Function struct {
+	// Name is the name of the function. If the function has a receiver, the
+	// name will be of the form T.N, where T is the type and N is the name.
+	Name string
+
+	// File is the full path to the file in which the function is defined.
+	File string
+
+	// Start is the start offset of the function's signature.
+	Start int
+
+	// End is the end offset of the function.
+	End int
+
+	// StartLine is the start line number of the function.
+	StartLine int
+
+	// EndLine is the end line number of the function.
+	EndLine int
+
+	// statements registered with this function.
+	Statements []*Statement
+}
+
+type Statement struct {
+	// Start is the start offset of the statement.
+	Start int
+
+	// End is the end offset of the statement.
+	End int
+
+	// StartLine is the start line number of the statement.
+	StartLine int
+
+	// EndLine is the end line number of the statement.
+	EndLine int
+
+	// Reached is the number of times the statement was reached.
+	Reached int64
+
+	// State indicates whether current statement is changed or not.
+	State State
+
+	// Mode indicates whether current statement counts for coverage.
+	Mode Mode
+}
+
+// State represents statement's state.
+// "Original" means it hasn't changed compared with compare branch (master or main)
+// "Changed" means it has been changed compared with compare branch (master or main)
+type State string
+
+// Mode represents statement's mode.
+// "Keep" means it will be used in coverage calculation
+// "Ignore" means it won't be used in coverage calculation
+type Mode string
+
+const (
+	Original State = "Original"
+	Changed  State = "Changed"
+
+	Keep   Mode = "Keep"
+	Ignore Mode = "Ignore"
+)
+
+// Accumulate will accumulate the coverage information from the provided
+// Package into this Package.
+func (p *Package) Accumulate(p2 *Package) error {
+	if p.Name != p2.Name {
+		return fmt.Errorf("names do not match: %q != %q", p.Name, p2.Name)
+	}
+	if len(p.Functions) != len(p2.Functions) {
+		return fmt.Errorf("function counts do not match: %d != %d", len(p.Functions), len(p2.Functions))
+	}
+	for i, f := range p.Functions {
+		err := f.Accumulate(p2.Functions[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Accumulate will accumulate the coverage information from the provided
+// Function into this Function.
+func (f *Function) Accumulate(f2 *Function) error {
+	if f.Name != f2.Name {
+		return fmt.Errorf("names do not match: %q != %q", f.Name, f2.Name)
+	}
+	if f.File != f2.File {
+		return fmt.Errorf("files do not match: %q != %q", f.File, f2.File)
+	}
+	if f.Start != f2.Start || f.End != f2.End {
+		return fmt.Errorf("source ranges do not match: %d-%d != %d-%d", f.Start, f.End, f2.Start, f2.End)
+	}
+	if len(f.Statements) != len(f2.Statements) {
+		return fmt.Errorf("number of statements do not match: %d != %d", len(f.Statements), len(f2.Statements))
+	}
+	for i, s := range f.Statements {
+		err := s.Accumulate(f2.Statements[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Accumulate will accumulate the coverage information from the provided
+// Statement into this Statement.
+func (s *Statement) Accumulate(s2 *Statement) error {
+	if s.Start != s2.Start || s.End != s2.End {
+		return fmt.Errorf("source ranges do not match: %d-%d != %d-%d", s.Start, s.End, s2.Start, s2.End)
+	}
+	s.Reached += s2.Reached
+	return nil
+}
+
+// Packages represents a set of Package structures.
+// The "AddPackage" method may be used to merge package
+// coverage results into the set.
+type Packages []*Package
+
+// AddPackage adds a package's coverage information to the
+func (ps *Packages) AddPackage(p *Package) {
+	i := sort.Search(len(*ps), func(i int) bool {
+		return (*ps)[i].Name >= p.Name
+	})
+	if i < len(*ps) && (*ps)[i].Name == p.Name {
+		(*ps)[i].Accumulate(p)
+	} else {
+		head := (*ps)[:i]
+		tail := append([]*Package{p}, (*ps)[i:]...)
+		*ps = append(head, tail...)
+	}
+}
+
+// ReadPackages takes a list of filenames and parses their
+// contents as a Packages object.
+//
+// The special filename "-" may be used to indicate standard input.
+// Duplicate filenames are ignored.
+func ReadPackages(filenames []string) (ps Packages, err error) {
+	copy_ := make([]string, len(filenames))
+	copy(copy_, filenames)
+	filenames = copy_
+	sort.Strings(filenames)
+
+	// Eliminate duplicates.
+	unique := []string{filenames[0]}
+	if len(filenames) > 1 {
+		for _, f := range filenames[1:] {
+			if f != unique[len(unique)-1] {
+				unique = append(unique, f)
+			}
+		}
+	}
+
+	// Open files.
+	var files []*os.File
+	for _, f := range filenames {
+		if f == "-" {
+			files = append(files, os.Stdin)
+		} else {
+			file, err := os.Open(f)
+			if err != nil {
+				return nil, err
+			}
+			defer file.Close()
+			files = append(files, os.Stdin)
+		}
+	}
+
+	// Parse the files, accumulate Packages.
+	for _, file := range files {
+		data, err := ioutil.ReadAll(file)
+		if err != nil {
+			return nil, err
+		}
+		result := &struct{ Packages []*Package }{}
+		err = json.Unmarshal(data, result)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range result.Packages {
+			ps.AddPackage(p)
+		}
+	}
+	return ps, nil
+}

--- a/pkg/parser/packages_test.go
+++ b/pkg/parser/packages_test.go
@@ -1,0 +1,118 @@
+package parser
+
+import "testing"
+
+func registerPackage(name string) *Package {
+	return &Package{Name: name}
+}
+
+func registerFunction(p *Package, name, file string, startOffset, endOffset int) *Function {
+	f := &Function{Name: name, File: file, Start: startOffset, End: endOffset}
+	p.Functions = append(p.Functions, f)
+	return f
+}
+
+func registerStatement(f *Function, startOffset, endOffset int) *Statement {
+	s := &Statement{Start: startOffset, End: endOffset}
+	f.Statements = append(f.Statements, s)
+	return s
+}
+
+func TestAccumulatePackage(t *testing.T) {
+	p1_1 := registerPackage("p1")
+	p1_2 := registerPackage("p1")
+	p2 := registerPackage("p2")
+	p3 := registerPackage("p1")
+	registerFunction(p3, "f", "file.go", 0, 1)
+	p4 := registerPackage("p1")
+	registerFunction(p4, "f", "file.go", 1, 2)
+
+	var tests = [...]struct {
+		a, b       *Package
+		expectPass bool
+	}{
+		// Should work: everything is the same.
+		{p1_1, p1_2, true},
+		// Should fail: name is different.
+		{p1_1, p2, false},
+		// Should fail: numbers of functions are different.
+		{p1_1, p3, false},
+		// Should fail: functions are different.
+		{p3, p4, false},
+	}
+
+	for _, test := range tests {
+		err := test.a.Accumulate(test.b)
+		if test.expectPass {
+			if err != nil {
+				t.Error(err)
+			}
+		} else {
+			if err == nil {
+				t.Error("Expected an error")
+			}
+		}
+	}
+}
+
+func TestAccumulateFunction(t *testing.T) {
+	p := registerPackage("p1")
+	f1_1 := registerFunction(p, "f1", "file.go", 0, 1)
+	f1_2 := registerFunction(p, "f1", "file.go", 0, 1)
+	f2 := registerFunction(p, "f2", "file.go", 0, 1)
+	f3 := registerFunction(p, "f1", "file2.go", 0, 1)
+	f4 := registerFunction(p, "f1", "file.go", 2, 3)
+	f5 := registerFunction(p, "f1", "file.go", 0, 1)
+	registerStatement(f5, 0, 1)
+	f6 := registerFunction(p, "f1", "file.go", 0, 1)
+	registerStatement(f6, 2, 3)
+
+	var tests = [...]struct {
+		a, b       *Function
+		expectPass bool
+	}{
+		// Should work: everything is the same.
+		{f1_1, f1_2, true},
+		// Should fail: names are different.
+		{f1_1, f2, false},
+		// Should fail: files are different.
+		{f1_1, f3, false},
+		// Should fail: ranges are different.
+		{f1_1, f4, false},
+		// Should fail: numbers of statements are different.
+		{f1_1, f5, false},
+		// Should fail: all the same, except statement values.
+		{f5, f6, false},
+	}
+
+	for _, test := range tests {
+		err := test.a.Accumulate(test.b)
+		if test.expectPass {
+			if err != nil {
+				t.Error(err)
+			}
+		} else {
+			if err == nil {
+				t.Error("Expected an error")
+			}
+		}
+	}
+}
+
+func TestAccumulateStatement(t *testing.T) {
+	p := registerPackage("p1")
+	f := registerFunction(p, "f1", "file.go", 0, 1)
+	s1_1 := registerStatement(f, 0, 1)
+	s1_2 := registerStatement(f, 0, 1)
+	s2 := registerStatement(f, 2, 3)
+
+	// Should work: ranges are the same.
+	if err := s1_1.Accumulate(s1_2); err != nil {
+		t.Error(err)
+	}
+
+	// Should fail: ranges are not the same.
+	if err := s1_1.Accumulate(s2); err == nil {
+		t.Errorf("Expected an error")
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,404 @@
+package parser
+
+import (
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/gocover/pkg/annotation"
+	"github.com/Azure/gocover/pkg/gittool"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/tools/cover"
+)
+
+type packagesCache map[string]*build.Package
+
+func NewParser(
+	coverProfileFiles []string,
+	logger logrus.FieldLogger,
+) *Parser {
+	return &Parser{
+		coverProfileFiles: coverProfileFiles,
+		packages:          make(map[string]*Package),
+		packagesCache:     make(packagesCache),
+		logger:            logger.WithField("source", "Parser"),
+	}
+}
+
+// Parser wrapper for parsing
+type Parser struct {
+	packages          map[string]*Package
+	packagesCache     packagesCache
+	coverProfileFiles []string
+
+	logger logrus.FieldLogger
+}
+
+// Parse parses cover profiles into statements, and modify their state based on git changes.
+func (parser *Parser) Parse(changes []*gittool.Change) (*Packages, error) {
+	var result Packages
+
+	for _, coverProfile := range parser.coverProfileFiles {
+
+		profiles, err := cover.ParseProfiles(coverProfile)
+		if err != nil {
+			err = fmt.Errorf("parse cover profile: %w", err)
+			parser.logger.WithError(err).Error()
+			return nil, err
+		}
+		for _, p := range profiles {
+			if err := parser.convertProfile(p, findChange(p, changes)); err != nil {
+				err = fmt.Errorf("covert cover profile: %w", err)
+				parser.logger.WithError(err).Error()
+				return nil, err
+			}
+		}
+
+		for _, pkg := range parser.packages {
+			result.AddPackage(pkg)
+		}
+	}
+
+	return &result, nil
+}
+
+// wrapper for Statement
+type statement struct {
+	*Statement
+	*StmtExtent
+}
+
+func (parser *Parser) convertProfile(p *cover.Profile, change *gittool.Change) error {
+	file, pkgpath, err := findFile(parser.packagesCache, p.FileName)
+	if err != nil {
+		err = fmt.Errorf("find file: %w", err)
+		parser.logger.WithError(err).Error()
+		return err
+	}
+	parser.logger.Debugf("[file=%s, pkgPath=%s]", file, pkgpath)
+
+	pkg := parser.packages[pkgpath]
+	if pkg == nil {
+		pkg = &Package{Name: pkgpath}
+		parser.packages[pkgpath] = pkg
+	}
+
+	ignoreProfile, err := annotation.ParseIgnoreProfiles(file, p)
+	if err != nil {
+		err = fmt.Errorf("parse ignore profile")
+		parser.logger.WithError(err).Error()
+		return err
+	}
+
+	// Find function and statement extents; create corresponding
+	// Functions and Statements, and keep a separate
+	// slice of Statements so we can match them with profile
+	// blocks.
+	extents, err := findFuncs(file)
+	if err != nil {
+		err = fmt.Errorf("find Functions: %w", err)
+		parser.logger.WithError(err).Error("")
+		return err
+	}
+	var stmts []statement
+	for _, fe := range extents {
+		f := &Function{
+			Name:      fe.name,
+			File:      file,
+			Start:     fe.startOffset,
+			End:       fe.endOffset,
+			StartLine: fe.startLine,
+			EndLine:   fe.endLine,
+		}
+		for _, se := range fe.stmts {
+			s := statement{
+				Statement: &Statement{
+					StartLine: se.startLine,
+					EndLine:   se.endLine,
+					Start:     se.startOffset,
+					End:       se.endOffset,
+					Mode:      Keep,
+					State:     findState(se, change),
+				},
+				StmtExtent: se,
+			}
+			f.Statements = append(f.Statements, s.Statement)
+			stmts = append(stmts, s)
+		}
+		pkg.Functions = append(pkg.Functions, f)
+	}
+	// For each profile block in the file, find the statement(s) it
+	// covers and increment the Reached field(s).
+	blocks := p.Blocks
+	for _, s := range stmts {
+
+		// ignore all statements when meet file ignore annotation
+		if ignoreProfile != nil && ignoreProfile.Type == annotation.FILE_IGNORE {
+			s.Mode = Ignore
+			s.Reached = 1
+			parser.logger.Debugf("hit file ignore on [%s], ignore statement at line %d", file, s.startLine)
+			continue
+		}
+
+		for i, b := range blocks {
+			if b.StartLine > s.endLine || (b.StartLine == s.endLine && b.StartCol >= s.endCol) {
+				// Past the end of the statement
+				blocks = blocks[i:]
+				break
+			}
+			if b.EndLine < s.startLine || (b.EndLine == s.startLine && b.EndCol <= s.startCol) {
+				// Before the beginning of the statement
+				continue
+			}
+			s.Reached += int64(b.Count)
+
+			// ignore those statements when block annotated with block ignore annotation
+			if _, ok := ignoreProfile.IgnoreBlocks[b]; ok {
+				s.Mode = Ignore
+				parser.logger.Debugf("hit block ignore on [%s], ignore statement at line %d", file, s.startLine)
+			}
+
+			break
+		}
+	}
+	return nil
+}
+
+// findFile finds the location of the named file in GOROOT, GOPATH etc.
+func findFile(packages packagesCache, file string) (filename, pkgpath string, err error) {
+	dir, file := filepath.Split(file)
+	if dir != "" {
+		dir = strings.TrimSuffix(dir, "/")
+	}
+	pkg, ok := packages[dir]
+	if !ok {
+		pkg, err = build.Import(dir, ".", build.FindOnly)
+		if err != nil {
+			return "", "", fmt.Errorf("can't find %q: %w", file, err)
+		}
+		packages[dir] = pkg
+	}
+
+	return filepath.Join(pkg.Dir, file), pkg.ImportPath, nil
+}
+
+// findFuncs parses the file and returns a slice of FuncExtent descriptors.
+func findFuncs(name string) ([]*FuncExtent, error) {
+	fset := token.NewFileSet()
+	parsedFile, err := parser.ParseFile(fset, name, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	visitor := &FuncVisitor{fset: fset}
+	ast.Walk(visitor, parsedFile)
+	return visitor.funcs, nil
+}
+
+type extent struct {
+	startOffset int
+	startLine   int
+	startCol    int
+	endOffset   int
+	endLine     int
+	endCol      int
+}
+
+// FuncExtent describes a function's extent in the source by file and position.
+type FuncExtent struct {
+	extent
+	name  string
+	stmts []*StmtExtent
+}
+
+// StmtExtent describes a statements's extent in the source by file and position.
+type StmtExtent extent
+
+// FuncVisitor implements the visitor that builds the function position list for a file.
+type FuncVisitor struct {
+	fset  *token.FileSet
+	funcs []*FuncExtent
+}
+
+func functionName(f *ast.FuncDecl) string {
+	name := f.Name.Name
+	if f.Recv == nil {
+		return name
+	} else {
+		// Function name is prepended with "T." if there is a receiver, where
+		// T is the type of the receiver, dereferenced if it is a pointer.
+		return exprName(f.Recv.List[0].Type) + "." + name
+	}
+}
+
+func exprName(x ast.Expr) string {
+	switch y := x.(type) {
+	case *ast.StarExpr:
+		return exprName(y.X)
+	case *ast.IndexExpr:
+		return fmt.Sprintf("%s[%s]", exprName(y.X), exprName(y.Index))
+	case *ast.Ident:
+		return y.Name
+	default:
+		return ""
+	}
+}
+
+// Visit implements the ast.Visitor interface.
+func (v *FuncVisitor) Visit(node ast.Node) ast.Visitor {
+	var body *ast.BlockStmt
+	var name string
+	switch n := node.(type) {
+	case *ast.FuncLit:
+		body = n.Body
+	case *ast.FuncDecl:
+		body = n.Body
+		name = functionName(n)
+	}
+	if body != nil {
+		start := v.fset.Position(node.Pos())
+		end := v.fset.Position(node.End())
+		if name == "" {
+			name = fmt.Sprintf("@%d:%d", start.Line, start.Column)
+		}
+		fe := &FuncExtent{
+			name: name,
+			extent: extent{
+				startOffset: start.Offset,
+				startLine:   start.Line,
+				startCol:    start.Column,
+				endOffset:   end.Offset,
+				endLine:     end.Line,
+				endCol:      end.Column,
+			},
+		}
+		v.funcs = append(v.funcs, fe)
+		sv := StmtVisitor{fset: v.fset, function: fe}
+		sv.VisitStmt(body)
+	}
+	return v
+}
+
+type StmtVisitor struct {
+	fset     *token.FileSet
+	function *FuncExtent
+}
+
+func (v *StmtVisitor) VisitStmt(s ast.Stmt) {
+	var statements *[]ast.Stmt
+	switch s := s.(type) {
+	case *ast.BlockStmt:
+		statements = &s.List
+	case *ast.CaseClause:
+		statements = &s.Body
+	case *ast.CommClause:
+		statements = &s.Body
+	case *ast.ForStmt:
+		if s.Init != nil {
+			v.VisitStmt(s.Init)
+		}
+		if s.Post != nil {
+			v.VisitStmt(s.Post)
+		}
+		v.VisitStmt(s.Body)
+	case *ast.IfStmt:
+		if s.Init != nil {
+			v.VisitStmt(s.Init)
+		}
+		v.VisitStmt(s.Body)
+		if s.Else != nil {
+			// Code copied from go.tools/cmd/cover, to deal with "if x {} else if y {}"
+			const backupToElse = token.Pos(len("else ")) // The AST doesn't remember the else location. We can make an accurate guess.
+			switch stmt := s.Else.(type) {
+			case *ast.IfStmt:
+				block := &ast.BlockStmt{
+					Lbrace: stmt.If - backupToElse, // So the covered part looks like it starts at the "else".
+					List:   []ast.Stmt{stmt},
+					Rbrace: stmt.End(),
+				}
+				s.Else = block
+			case *ast.BlockStmt:
+				stmt.Lbrace -= backupToElse // So the block looks like it starts at the "else".
+			default:
+				panic("unexpected node type in if")
+			}
+			v.VisitStmt(s.Else)
+		}
+	case *ast.LabeledStmt:
+		v.VisitStmt(s.Stmt)
+	case *ast.RangeStmt:
+		v.VisitStmt(s.Body)
+	case *ast.SelectStmt:
+		v.VisitStmt(s.Body)
+	case *ast.SwitchStmt:
+		if s.Init != nil {
+			v.VisitStmt(s.Init)
+		}
+		v.VisitStmt(s.Body)
+	case *ast.TypeSwitchStmt:
+		if s.Init != nil {
+			v.VisitStmt(s.Init)
+		}
+		v.VisitStmt(s.Assign)
+		v.VisitStmt(s.Body)
+	}
+	if statements == nil {
+		return
+	}
+	for i := 0; i < len(*statements); i++ {
+		s := (*statements)[i]
+		switch s.(type) {
+		case *ast.CaseClause, *ast.CommClause, *ast.BlockStmt:
+			break
+		default:
+			start, end := v.fset.Position(s.Pos()), v.fset.Position(s.End())
+			se := &StmtExtent{
+				startOffset: start.Offset,
+				startLine:   start.Line,
+				startCol:    start.Column,
+				endOffset:   end.Offset,
+				endLine:     end.Line,
+				endCol:      end.Column,
+			}
+			v.function.stmts = append(v.function.stmts, se)
+		}
+		v.VisitStmt(s)
+	}
+}
+
+// findState check the change line
+// if it hits the statement, means change on that statement, and return "Changed"
+// otherwise, return "Original"
+func findState(stmt *StmtExtent, change *gittool.Change) State {
+	if change == nil {
+		return Original
+	}
+
+	for _, s := range change.Sections {
+		for i := s.StartLine; i < s.EndLine; i++ {
+			if stmt.startLine <= i && stmt.endLine >= i {
+				return Changed
+			}
+		}
+	}
+
+	return Original
+}
+
+// findChange find the expected change by file name.
+func findChange(profile *cover.Profile, changes []*gittool.Change) *gittool.Change {
+	for _, change := range changes {
+		if InFolder(profile.FileName, change.FileName) {
+			return change
+		}
+	}
+	return nil
+}
+
+// InFolder check whether specified filepath is a part of parent path.
+func InFolder(parentDir, filepath string) bool {
+	return strings.HasSuffix(parentDir, filepath)
+}


### PR DESCRIPTION
Use AST can gain a lot of information about go source code, such can make a better coverage calculation.
Parser parses the cover profile and translates each tested go files into single statement. Based on statement, the coverage is more accurate than line based.