### PR TITLE
add coverpkg flag to go test enable cross package coverage

### DIFF
--- a/pkg/gittool/diff.go
+++ b/pkg/gittool/diff.go
@@ -144,7 +144,8 @@ func (g *gitClient) buildChangeFromPatch(filePatch diff.FilePatch) (*Change, err
 
 func isGoFile(fileInfo diff.File) bool {
 	return fileInfo.Mode() == filemode.Regular &&
-		strings.HasSuffix(fileInfo.Path(), ".go")
+		strings.HasSuffix(fileInfo.Path(), ".go") &&
+		!strings.HasSuffix(fileInfo.Path(), "_test.go")
 }
 
 // buildChangeFromChunks builds the diff change from git chunks.

--- a/pkg/gittool/diff_test.go
+++ b/pkg/gittool/diff_test.go
@@ -393,6 +393,17 @@ func TestIsGoFile(t *testing.T) {
 				return filemode.Regular
 			},
 			PathFn: func() string {
+				return "pkg/foo_test.go"
+			},
+		}); result != false {
+			t.Errorf("should false but return %t", result)
+		}
+
+		if result := isGoFile(&mockFile{
+			ModeFn: func() filemode.FileMode {
+				return filemode.Regular
+			},
+			PathFn: func() string {
 				return "pkg/config.yaml"
 			},
 		}); result != false {

--- a/pkg/gocover/diffcover.go
+++ b/pkg/gocover/diffcover.go
@@ -35,7 +35,12 @@ func NewDiffCover(o *DiffOption) (GoCover, error) {
 		}
 	}
 
-	modulePath, err := parseGoModulePath(o.ModuleDir)
+	p, err := filepath.Abs(o.RepositoryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	modulePath, err := parseGoModulePath(filepath.Join(p, o.ModuleDir))
 	if err != nil {
 		return nil, fmt.Errorf("parse go module path: %w", err)
 	}

--- a/pkg/gocover/fullcover.go
+++ b/pkg/gocover/fullcover.go
@@ -32,7 +32,12 @@ func NewFullCover(o *FullOption) (GoCover, error) {
 		}
 	}
 
-	modulePath, err := parseGoModulePath(o.ModuleDir)
+	p, err := filepath.Abs(o.RepositoryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	modulePath, err := parseGoModulePath(filepath.Join(p, o.ModuleDir))
 	if err != nil {
 		return nil, fmt.Errorf("parse go module path: %w", err)
 	}

--- a/pkg/gocover/gocovertest.go
+++ b/pkg/gocover/gocovertest.go
@@ -3,6 +3,7 @@ package gocover
 import (
 	"context"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -14,7 +15,7 @@ import (
 
 func NewGoCoverTest(o *GoCoverTestOption) *goCoverTest {
 	return &goCoverTest{
-		moduleDir: o.ModuleDir,
+		moduleDir: filepath.Join(o.RepositoryPath, o.ModuleDir),
 		outputDir: o.Output,
 		stdout:    o.StdOut,
 		stderr:    o.StdErr,
@@ -43,8 +44,11 @@ func (t *goCoverTest) RunTests(ctx context.Context) error {
 		t.outputDir = tmpDir
 	}
 
+	if err := os.MkdirAll(t.outputDir, fs.ModePerm); err != nil {
+		return err
+	}
 	coverFile := filepath.Join(t.outputDir, "coverage.out")
-	cmd := exec.Command(goCmd(), "test", "./...", "-coverprofile", coverFile, "-v")
+	cmd := exec.Command(goCmd(), "test", "./...", "-coverprofile", coverFile, "-coverpkg=./...", "-v")
 	cmd.Dir = t.moduleDir
 	cmd.Stdin = nil
 	cmd.Stdout = t.stdout


### PR DESCRIPTION
add `-coverpkg` flag to go test, thus it can generate cross pkg coverage profile.