### PR TITLE
remove parallel flag for ginkgo run

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ gocover full --repository-path=${REPO ROOT PATH} --cover-profile=${PATH TO}cover
 Use following command to run the unit tests and get coverage on the module.
 The cover profiles and coverage result are written in the output directory.
 
-* `--executor-mode`, what test framework to run the unit tests. `go` uses `go test ./... -coverpkg=./...`, `ginkgo` uses `-p -r -trace -cover -coverpkg ./... ./` to run the unit tests.
+* `--executor-mode`, what test framework to run the unit tests. `go` uses `go test ./... -coverpkg=./...`, `ginkgo` uses `ginkgo -r -trace -cover -coverpkg ./... ./` to run the unit tests.
 
 ```bash
 gocover test --repository-path=${REPO ROOT PATH} --coverage-mode [full|diff] --executor-mode [go|ginkgo] --outputdir /tmp

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -253,5 +253,7 @@ func newGoCoverTestCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.Style, "style", "colorful", "coverage report code format style, refer to https://pygments.org/docs/styles for more information")
 	cmd.Flags().StringVar((*string)(&o.CoverageMode), "coverage-mode", string(gocover.FullCoverage), `mode for coverage, "full" or "diff"`)
 	cmd.Flags().StringVar((*string)(&o.ExecutorMode), "executor-mode", string(gocover.GoExecutor), `unit test mode, "go" or "ginkgo"`)
+	cmd.Flags().StringSliceVar(&o.GoTestFlags, "go-flags", []string{}, "flags for go test")
+	cmd.Flags().StringSliceVar(&o.GinkgoFlags, "ginkgo-flags", []string{}, "flags for ginkgo")
 	return cmd
 }

--- a/pkg/gocover/executor.go
+++ b/pkg/gocover/executor.go
@@ -204,7 +204,7 @@ func mergeCoverProfiles(outputdir string, coverProfiles []string) (string, error
 
 func (executor *ginkgoTestExecutor) runTests(ctx context.Context) error {
 	buildString := fmt.Sprintf("%s build -r -cover -coverpkg ./... ./", executor.executable)
-	runString := fmt.Sprintf("%s -p -r -trace -cover -coverpkg ./... ./", executor.executable)
+	runString := fmt.Sprintf("%s -r -trace -cover -coverpkg ./... ./", executor.executable)
 
 	workingDir := filepath.Join(executor.repositoryPath, executor.moduleDir)
 	logger := executor.logger.WithFields(logrus.Fields{
@@ -227,13 +227,13 @@ func (executor *ginkgoTestExecutor) runTests(ctx context.Context) error {
 	logger.Infof("ginkgo tests built sucessfully")
 
 	logger.Infof("executing cmd: %s", runString)
-	runCmd := exec.Command(executor.executable, "-p", "-r", "-trace", "-cover", "-coverpkg", "./...", "./")
+	runCmd := exec.Command(executor.executable, "-r", "-trace", "-cover", "-coverpkg", "./...", "./")
 	runCmd.Dir = workingDir
 	runCmd.Stdin = nil
 	runCmd.Stdout = executor.stdout
 	runCmd.Stderr = executor.stderr
 	if err := runCmd.Run(); err != nil {
-		err = fmt.Errorf(`executing cmd %s failed: %w`, buildString, err)
+		err = fmt.Errorf(`executing cmd: %s failed: %w`, runString, err)
 		logger.WithError(err).Error()
 		return err
 	}

--- a/pkg/gocover/options.go
+++ b/pkg/gocover/options.go
@@ -94,6 +94,8 @@ type GoCoverTestOption struct {
 	ModulePath     string
 	CoverageMode   CoverageMode
 	ExecutorMode   ExecutorMode
+	GoTestFlags    []string
+	GinkgoFlags    []string
 
 	CoverageBaseline float64
 	ReportFormat     string


### PR DESCRIPTION
`-p` flag may embrace port is in used issue for test cases that using local server.