### PR TITLE
add excludes glob support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Use following command to run the unit tests and get coverage on the module.
 The cover profiles and coverage result are written in the output directory.
 
 * `--executor-mode`, what test framework to run the unit tests. `go` uses `go test ./... -coverpkg=./...`, `ginkgo` uses `-p -r -trace -cover -coverpkg ./... ./` to run the unit tests.
+* `--excludes`, exclude the files that match the exclude patterns, the excluded files won't be used to calculate coverage result.
 
 ```bash
-gocover test --repository-path=${REPO ROOT PATH} --coverage-mode [full|diff] --executor-mode [go|ginkgo] --outputdir /tmp
+gocover test --repository-path=${REPO ROOT PATH} --coverage-mode [full|diff] --executor-mode [go|ginkgo] --excludes '**/mock_*/**' --outputdir /tmp
 ```
 
 For the project has multiple module, please specify `module-dir` to generates the coverage for the module. `module-dir` flag is the relative path to the root of the project.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-kusto-go v0.7.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/alecthomas/chroma/v2 v2.2.0
+	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bmatcuk/doublestar/v4 v4.2.0 h1:Qu+u9wR3Vd89LnlLMHvnZ5coJMWKQamqdz9/p5GNthA=
+github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/gocover/cover.go
+++ b/pkg/gocover/cover.go
@@ -2,6 +2,7 @@ package gocover
 
 import "context"
 
+// GoCover interface to generate coverage result.
 type GoCover interface {
 	Run(ctx context.Context) error
 }

--- a/pkg/gocover/executor.go
+++ b/pkg/gocover/executor.go
@@ -161,7 +161,7 @@ func (e *ginkgoTestExecutor) Run(ctx context.Context) error {
 		return err
 	}
 
-	e.logger.Infof("cover profiles: %s", coverFiles)
+	e.logger.Infof("cover profile: %s", mergedFile)
 	if err := gocover.Run(ctx); err != nil {
 		err := fmt.Errorf("run gocover: %w", err)
 		e.logger.WithError(err).Error()

--- a/pkg/gocover/funcs.go
+++ b/pkg/gocover/funcs.go
@@ -9,10 +9,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Azure/gocover/pkg/dbclient"
 	"github.com/Azure/gocover/pkg/report"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/modfile"
 )
@@ -23,12 +25,67 @@ const (
 	DefaultCoverageBaseline = 80.0
 )
 
+// excludeFileCache cache contains exclude file
+type excludeFileCache map[string]bool
+
+func inExclueds(cache excludeFileCache, excludesPattern []string, fileName string, logger logrus.FieldLogger) bool {
+	if _, ok := cache[fileName]; ok {
+		return true
+	}
+
+	for _, pattern := range excludesPattern {
+		match, err := doublestar.PathMatch(pattern, fileName)
+		if err != nil {
+			logger.Warnf("path match [%s, %s] %w", pattern, fileName, err)
+			continue
+		}
+		if match {
+			cache[fileName] = true
+			logger.Debugf("exculde file: [%s, %s]", fileName, pattern)
+			return true
+		}
+	}
+	return false
+}
+
 // calculateCoverage calculate coverage proportion
 func calculateCoverage(covered int64, effectived int64) float64 {
 	if effectived == 0 {
 		return 100.0
 	}
 	return float64(covered) / float64(effectived) * 100
+}
+
+// reBuildStatistics rebuild fields of Statistics from its CoverageProfile
+func reBuildStatistics(s *report.Statistics, cache excludeFileCache) {
+	for _, p := range s.CoverageProfile {
+		s.TotalLines += p.TotalLines
+		s.TotalCoveredLines += p.CoveredLines
+		s.TotalEffectiveLines += p.TotalEffectiveLines
+		s.TotalIgnoredLines += p.TotalIgnoredLines
+	}
+
+	s.TotalCoveragePercent = calculateCoverage(
+		int64(s.TotalCoveredLines),
+		int64(s.TotalEffectiveLines),
+	)
+
+	for f := range cache {
+		s.ExcludeFiles = append(s.ExcludeFiles, f)
+	}
+}
+
+// formatFilePath format filename that strip root path and adds module path
+// fileNamePath is the absolute path of the file, modulePath is the module path of go module
+// for example:
+//    rootRepoPath: /home/User/go/src/Azure/gocover
+//    fileNamePath: /home/User/go/src/Azure/gocover/pkg/foo/foo.go
+//    modulePath: github.com/Azure/gocover
+// it returns github.com/Azure/gocover/foo/foo.go
+func formatFilePath(rootRepoPath, fileNamePath, modulePath string) string {
+	return filepath.Join(modulePath,
+		strings.TrimPrefix(fileNamePath, rootRepoPath),
+	)
 }
 
 // store send all coverage results to db store
@@ -72,7 +129,7 @@ func dump(all []*report.AllInformation, logger logrus.FieldLogger) {
 
 type fileContentsCache map[string][]string
 
-// findFileContents finds the contents of specific file.
+// findFileContents finds the contents of specific file. filename is the absolute path of the file.
 func findFileContents(fileCache fileContentsCache, filename string) ([]string, error) {
 	result, ok := fileCache[filename]
 	if !ok {
@@ -111,6 +168,7 @@ func parseGoModulePath(goModDir string) (string, error) {
 	return result, nil
 }
 
+// createGoCoverTempDirectory creates temp directory that used for gocover outputs
 func createGoCoverTempDirectory() (string, error) {
 	tmpDir, err := ioutil.TempDir("", "gocover")
 	if err != nil {

--- a/pkg/report/generator_test.go
+++ b/pkg/report/generator_test.go
@@ -44,10 +44,10 @@ func TestGenerateReport(t *testing.T) {
 
 		reportString := string(data)
 		if !strings.Contains(reportString, "No lines with coverage information in this diff.") {
-			t.Error("report should contains empty diff information")
+			t.Error("report should contain empty diff information")
 		}
 		if !strings.Contains(reportString, "origin/master") {
-			t.Error("report should contains compared branch 'origin/master'")
+			t.Error("report should contain compared branch 'origin/master'")
 		}
 	})
 
@@ -63,6 +63,7 @@ func TestGenerateReport(t *testing.T) {
 			TotalIgnoredLines:    2,
 			TotalViolationLines:  2,
 			TotalCoveragePercent: 70,
+			ExcludeFiles:         []string{"exclude.txt"},
 			CoverageProfile: []*CoverageProfile{
 				{
 					FileName:            "foo.txt",
@@ -118,6 +119,9 @@ func TestGenerateReport(t *testing.T) {
 		}
 		if !strings.Contains(string(data), "Diff Coverage") {
 			t.Error("report header should contain 'Diff Coverage'")
+		}
+		if !strings.Contains(string(data), "Exclude Files") {
+			t.Error("report should contain 'Exclude Files' header")
 		}
 		for _, v := range []string{"foo", "bar", "zoo", "text1", "text2", "text3", "foo.txt", "bar.txt"} {
 			if !strings.Contains(reportString, v) {

--- a/pkg/report/templates.go
+++ b/pkg/report/templates.go
@@ -35,74 +35,83 @@ var htmlCoverageReport = "" +
     {{ end }}
 
     {{ if .CoverageProfile }}
-    <ul>
-        <li>
-            <b>Total</b>: {{ NormalizeLines .TotalLines }}
-        </li>
-        <li>
-            <b>Effective</b>: {{ NormalizeLines .TotalEffectiveLines }}
-        </li>
-        <li>
-            <b>Covered</b>: {{ NormalizeLines .TotalCoveredLines }}
-        </li>
-        <li>
-            <b>Ignored</b>: {{ NormalizeLines .TotalIgnoredLines }}
-        </li>
-        <li>
-            <b>Coverage</b>: {{ .TotalCoveragePercent }}%
-        </li>
-    </ul>
+        <ul>
+            <li>
+                <b>Total</b>: {{ NormalizeLines .TotalLines }}
+            </li>
+            <li>
+                <b>Effective</b>: {{ NormalizeLines .TotalEffectiveLines }}
+            </li>
+            <li>
+                <b>Covered</b>: {{ NormalizeLines .TotalCoveredLines }}
+            </li>
+            <li>
+                <b>Ignored</b>: {{ NormalizeLines .TotalIgnoredLines }}
+            </li>
+            <li>
+                <b>Coverage</b>: {{ .TotalCoveragePercent }}%
+            </li>
+        </ul>
 
-    <p>
-        <b>Coverage</b> = Covered / Effective <br />
-        <b>Total</b> = Effective + Ignored
-    </p>
+        <p>
+            <b>Coverage</b> = Covered / Effective <br />
+            <b>Total</b> = Effective + Ignored
+        </p>
 
-    <table border="1">
-        <thead>
-            <tr>
-                <th>Source File</th>
-                {{ if IsFullCoverageReport .StatisticsType }}
-                    <th>Full Coverage (%)</th>
+        <table border="1">
+            <thead>
+                <tr>
+                    <th>Source File</th>
+                    {{ if IsFullCoverageReport .StatisticsType }}
+                        <th>Full Coverage (%)</th>
+                    {{ end }}
+                    {{ if IsDiffCoverageReport .StatisticsType }}
+                        <th>Diff Coverage (%)</th>
+                    {{ end }}
+                    <th>Covered Lines</th>
+                    <th>Ignored Lines</th>
+                    <th>Effective Lines</th>
+                    <th>Total Lines</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ range .CoverageProfile }}
+                <tr>
+                    <td>{{ .FileName }}</td>
+                    <td>{{ PercentCovered .TotalEffectiveLines .CoveredLines }}</td>
+                    <td>{{ .CoveredLines }}</td>
+                    <td>{{ .TotalIgnoredLines }}</td>
+                    <td>{{ .TotalEffectiveLines }}</td>
+                    <td>{{ .TotalLines }}</td>
+                </tr>
                 {{ end }}
-                {{ if IsDiffCoverageReport .StatisticsType }}
-                    <th>Diff Coverage (%)</th>
-                {{ end }}
-                <th>Covered Lines</th>
-                <th>Ignored Lines</th>
-                <th>Effective Lines</th>
-                <th>Total Lines</th>
-            </tr>
-        </thead>
-        <tbody>
-            {{ range .CoverageProfile }}
-            <tr>
-                <td>{{ .FileName }}</td>
-                <td>{{ PercentCovered .TotalEffectiveLines .CoveredLines }}</td>
-                <td>{{ .CoveredLines }}</td>
-                <td>{{ .TotalIgnoredLines }}</td>
-                <td>{{ .TotalEffectiveLines }}</td>
-                <td>{{ .TotalLines }}</td>
-            </tr>
-            {{ end }}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
 
-    {{ range .CoverageProfile }}
-    <div class="src-snippet">
-        {{ if lt (PercentCovered .TotalEffectiveLines .CoveredLines) 100.0 }}
-        <div class="src-name">{{ .FileName }}</div>
-        <div class="snippets">
-            {{range .CodeSnippet}}
-            {{ . }}
-            {{ end }}
-        </div>
+        {{ range .CoverageProfile }}
+            <div class="src-snippet">
+                {{ if lt (PercentCovered .TotalEffectiveLines .CoveredLines) 100.0 }}
+                <div class="src-name">{{ .FileName }}</div>
+                <div class="snippets">
+                    {{range .CodeSnippet}}
+                    {{ . }}
+                    {{ end }}
+                </div>
+                {{ end }}
+            </div>
         {{ end }}
-    </div>
-    {{ end }}
 
     {{ else }}
-    <p>No lines with coverage information in this diff.</p>
+        <p>No lines with coverage information in this diff.</p>
+    {{ end }}
+
+    {{ if .ExcludeFiles }}
+        <h3>Exclude Files</h3>
+        <ul>
+        {{ range .ExcludeFiles }}
+            <li>{{ . }}</li>
+        {{ end }}
+        </ul>
     {{ end }}
 
 </body>

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -32,6 +32,8 @@ type Statistics struct {
 	CoverageProfile []*CoverageProfile
 	// StatisticsType indicates which type the Statistics is.
 	StatisticsType StatisticsType
+	// exclude files that won't take participate to coverage calculation.
+	ExcludeFiles []string
 }
 
 // CoverageProfile represents the test coverage information for a file.


### PR DESCRIPTION
Add support to exclude files that won't be used to calculate coverage result.
Use `--excludes` flag to pass the glob exclude patterns, multiple patterns can be combined with `,`, for example `--excludes '**/mock_*/**,**/exclude/**'`