### PR TITLE
Support override flags for ginkgo

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -253,5 +253,7 @@ func newGoCoverTestCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.Style, "style", "colorful", "coverage report code format style, refer to https://pygments.org/docs/styles for more information")
 	cmd.Flags().StringVar((*string)(&o.CoverageMode), "coverage-mode", string(gocover.FullCoverage), `mode for coverage, "full" or "diff"`)
 	cmd.Flags().StringVar((*string)(&o.ExecutorMode), "executor-mode", string(gocover.GoExecutor), `unit test mode, "go" or "ginkgo"`)
+	cmd.Flags().StringSliceVar(&o.GinkgoFlags, "ginkgo-flags", []string{"-r", "-trace", "-cover", "-coverpkg=./..."}, "ginkgo flags")
+	cmd.Flags().StringSliceVar(&o.GoFlags, "go-flags", []string{}, "go flags")
 	return cmd
 }

--- a/pkg/gocover/options.go
+++ b/pkg/gocover/options.go
@@ -94,6 +94,8 @@ type GoCoverTestOption struct {
 	ModulePath     string
 	CoverageMode   CoverageMode
 	ExecutorMode   ExecutorMode
+	GinkgoFlags    []string
+	GoFlags        []string
 
 	CoverageBaseline float64
 	ReportFormat     string


### PR DESCRIPTION
Can use `--ginkgo-flags='-r,-trace,-cover,-coverpkg=./...'` to override the default behavior of ginkgo.