### PR TITLE
inject build information for gocover binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   create:
     tags:
-    - v*
+      - "v*.*.*"
 
 jobs:
 

--- a/main.go
+++ b/main.go
@@ -6,8 +6,19 @@ import (
 	"github.com/Azure/gocover/pkg/cmd"
 )
 
+var (
+	// Override following variables by -ldflags:
+	//  `go build -ldflags "-X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}"`
+	//
+	// Gocover uses goreleaser/goreleaser-action@v3 to help release, it automcatically inject following variables:
+	// which can be found at https://goreleaser.com/cookbooks/using-main.version
+	version = "v1.0.0"
+	commit  = "none"
+	date    = "2022-09-10T00:00:00Z" // https://pkg.go.dev/time#pkg-constants RFC3339
+)
+
 func main() {
-	command := cmd.NewGoCoverCommand()
+	command := cmd.NewGoCoverCommand(version, commit, date)
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -91,7 +91,7 @@ func createLogger(cmd *cobra.Command) *logrus.Logger {
 }
 
 // NewGoCoverCommand creates a command object for generating diff coverage reporter.
-func NewGoCoverCommand() *cobra.Command {
+func NewGoCoverCommand(version, commit, date string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:          "gocover",
@@ -119,22 +119,7 @@ func NewGoCoverCommand() *cobra.Command {
 	cmd.AddCommand(newDiffCoverageCommand())
 	cmd.AddCommand(newFullCoverageCommand())
 	cmd.AddCommand(newGoCoverTestCommand())
-	cmd.AddCommand(newVersionCommand())
-	return cmd
-}
-
-const VERSION = "1.0.0"
-
-func newVersionCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "version",
-		Short:   "print Gocover's version",
-		Example: "gocover version",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "Gocover Version %s\n", VERSION)
-			return nil
-		},
-	}
+	cmd.AddCommand(newVersionCommand(version, commit, date))
 	return cmd
 }
 

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand(version, commit, date string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:   "print Gocover's version",
+		Example: "gocover version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "Gocover Version %s\n", version)
+			fmt.Fprintf(cmd.OutOrStdout(), "Runtime SHA: %s\n", commit)
+			fmt.Fprintf(cmd.OutOrStdout(), "Created At: %s\n", date)
+			return nil
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Output version for gocover like following:
```bash
$ gocover version
Gocover Version 1.0.4
Runtime SHA: ca7b59673f2798cd69efe0a77a7743b7af18928e
Created At: 2022-09-10T04:30:50Z
```