### PR TITLE
Record unit test cover information even for file ignore

### DIFF
--- a/pkg/gocover/diffcover.go
+++ b/pkg/gocover/diffcover.go
@@ -218,7 +218,6 @@ func (diff *diffCover) generateStatistics() (*report.Statistics, error) {
 				if st.Mode == parser.Ignore {
 					diff.logger.Debugf("%s ignore line %d", fun.File, st.StartLine)
 					ignored++
-					continue
 				}
 				if st.Reached > 0 {
 					covered++

--- a/pkg/gocover/fullcover.go
+++ b/pkg/gocover/fullcover.go
@@ -182,7 +182,6 @@ func (full *fullCover) generateStatistics() (*report.Statistics, error) {
 					full.logger.Debugf("%s ignore line %d", fun.File, st.StartLine)
 					ignored++
 					node.TotalIgnoredLines += 1
-					continue
 				}
 				if st.Reached > 0 {
 					node.TotalCoveredLines += 1

--- a/pkg/gocover/funcs.go
+++ b/pkg/gocover/funcs.go
@@ -70,6 +70,10 @@ func reBuildStatistics(s *report.Statistics, cache excludeFileCache) {
 		int64(s.TotalCoveredLines),
 		int64(s.TotalEffectiveLines),
 	)
+	s.TotalCoverageWithoutIgnore = calculateCoverage(
+		int64(s.TotalCoveredLines),
+		int64(s.TotalLines),
+	)
 
 	for f := range cache {
 		s.ExcludeFiles = append(s.ExcludeFiles, f)

--- a/pkg/gocover/funcs_test.go
+++ b/pkg/gocover/funcs_test.go
@@ -109,9 +109,13 @@ func TestReBuildStatistics(t *testing.T) {
 		cache := excludeFileCache{"github.com/Azure/gocover/pkg/foo/foo.go": true}
 		reBuildStatistics(s, cache)
 
-		expectCveragePercent := calculateCoverage(30+15, 40+50)
-		if s.TotalCoveragePercent != expectCveragePercent {
-			t.Errorf("expect coverage percent %f, but get %f", expectCveragePercent, s.TotalCoveragePercent)
+		expectCoveragePercent := calculateCoverage(30+15, 40+50)
+		if s.TotalCoveragePercent != expectCoveragePercent {
+			t.Errorf("expect coverage percent %f, but get %f", expectCoveragePercent, s.TotalCoveragePercent)
+		}
+		expectCoveragePercentWithoutIgnore := calculateCoverage(30+15, 50+50)
+		if s.TotalCoverageWithoutIgnore != expectCoveragePercentWithoutIgnore {
+			t.Errorf("expect coverage percent %f, but get %f", expectCoveragePercentWithoutIgnore, s.TotalCoverageWithoutIgnore)
 		}
 		expectTotal := 50 + 50
 		if s.TotalLines != expectTotal {

--- a/pkg/report/generator_test.go
+++ b/pkg/report/generator_test.go
@@ -120,6 +120,12 @@ func TestGenerateReport(t *testing.T) {
 		if !strings.Contains(string(data), "Diff Coverage") {
 			t.Error("report header should contain 'Diff Coverage'")
 		}
+		if !strings.Contains(string(data), "Coverage (with ignorance)") {
+			t.Errorf("report should contain Coverage (with ignorance)")
+		}
+		if !strings.Contains(string(data), "Coverage") {
+			t.Errorf("report should contain Coverage")
+		}
 		if !strings.Contains(string(data), "Exclude Files") {
 			t.Error("report should contain 'Exclude Files' header")
 		}
@@ -192,7 +198,13 @@ func TestGenerateReport(t *testing.T) {
 
 		reportString := string(data)
 		if !strings.Contains(string(data), "Full Coverage") {
-			t.Error("report header should contain 'Diff Coverage'")
+			t.Error("report header should contain 'Full Coverage'")
+		}
+		if !strings.Contains(string(data), "Coverage (with ignorance)") {
+			t.Errorf("report should contain Coverage (with ignorance)")
+		}
+		if !strings.Contains(string(data), "Coverage") {
+			t.Errorf("report should contain Coverage")
 		}
 		for _, v := range []string{"foo", "bar", "zoo", "text1", "text2", "text3", "foo.txt", "bar.txt"} {
 			if !strings.Contains(reportString, v) {

--- a/pkg/report/templates.go
+++ b/pkg/report/templates.go
@@ -67,12 +67,16 @@ var htmlCoverageReport = "" +
                 <b>Ignored</b>: {{ NormalizeLines .TotalIgnoredLines }}
             </li>
             <li>
-                <b>Coverage</b>: {{ .TotalCoveragePercent }}%
+                <b>Coverage</b>: {{ .TotalCoverageWithoutIgnore }}%
+            </li>
+            <li>
+                <b>Coverage (with ignorance)</b>: {{ .TotalCoveragePercent }}%
             </li>
         </ul>
 
         <p>
-            <b>Coverage</b> = Covered / Effective <br />
+            <b>Coverage </b> = Covered / Total <br />
+            <b>Coverage (with ignorance) </b> = Covered / Effective <br />
             <b>Total</b> = Effective + Ignored
         </p>
 
@@ -81,9 +85,11 @@ var htmlCoverageReport = "" +
                 <tr>
                     <th>Source File</th>
                     {{ if IsFullCoverageReport .StatisticsType }}
+                        <th>Full Coverage (with ignorance) (%)</th>
                         <th>Full Coverage (%)</th>
                     {{ end }}
                     {{ if IsDiffCoverageReport .StatisticsType }}
+                        <th>Diff Coverage (with ignorance) (%)</th>
                         <th>Diff Coverage (%)</th>
                     {{ end }}
                     <th>Covered Lines</th>
@@ -97,6 +103,7 @@ var htmlCoverageReport = "" +
                 <tr>
                     <td><a href="#{{.FileName}}">{{ .FileName }}</a></td>
                     <td>{{ PercentCovered .TotalEffectiveLines .CoveredLines }}</td>
+                    <td>{{ PercentCovered .TotalLines .CoveredLines }}</td>
                     <td>{{ .CoveredLines }}</td>
                     <td>{{ .TotalIgnoredLines }}</td>
                     <td>{{ .TotalEffectiveLines }}</td>

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -28,6 +28,8 @@ type Statistics struct {
 	TotalViolationLines int
 	// TotalCoveragePercent represents the coverage percent for current diff.
 	TotalCoveragePercent float64
+	// TotalCoverageWithoutIgnore represents the coverage percent for current diff without ignorance
+	TotalCoverageWithoutIgnore float64
 	// CoverageProfile represents the coverage profile for a specific file.
 	CoverageProfile []*CoverageProfile
 	// StatisticsType indicates which type the Statistics is.


### PR DESCRIPTION
For file ignore annotation, it misses all the covered information, but it's still useful, so add it too.