### PR TITLE
Fix coverage is greater than 100%

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/gocover
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Azure/azure-kusto-go v0.8.0

--- a/pkg/dbclient/client.go
+++ b/pkg/dbclient/client.go
@@ -25,15 +25,17 @@ type DbClient interface {
 }
 
 type CoverageData struct {
-	PreciseTimestamp time.Time `json:"preciseTimestamp"` // time send to db
-	TotalLines       int64     `json:"totalLines"`       // total lines of the entire repo/module.
-	EffectiveLines   int64     `json:"effectiveLines"`   // the lines for coverage base, total lines - ignored lines
-	IgnoredLines     int64     `json:"ignoredLines"`     // the lines ignored.
-	CoveredLines     int64     `json:"coveredLines"`     // the lines covered by test
-	Coverage         float64   `json:"coverage"`         // unit test coverage, CoveredLines / EffectiveLines
-	CoverageMode     string    `json:"coverageMode"`     // coverage mode, diff or full subcommand
-	ModulePath       string    `json:"modulePath"`       // module name, which is declared in go.mod
-	FilePath         string    `json:"filePath"`         // file path for a concrete file or directory
+	PreciseTimestamp       time.Time `json:"preciseTimestamp"`       // time send to db
+	TotalLines             int64     `json:"totalLines"`             // total lines of the entire repo/module.
+	EffectiveLines         int64     `json:"effectiveLines"`         // the lines for coverage base, total lines - ignored lines
+	IgnoredLines           int64     `json:"ignoredLines"`           // the lines ignored.
+	CoveredLines           int64     `json:"coveredLines"`           // the lines covered by test
+	Coverage               float64   `json:"coverage"`               // unit test coverage, CoveredLines / TotalLines
+	CoverageWithIgnored    float64   `json:"coverageWithIgnorance"`  // unit test coverage exclude ignored lines, (CoveredLines - CoveredButIgnoredLines) / EffectiveLines
+	CoveredButIgnoredLines int64     `json:"coveredButIgnoredLines"` // the lines covered but ignored
+	CoverageMode           string    `json:"coverageMode"`           // coverage mode, diff or full subcommand
+	ModulePath             string    `json:"modulePath"`             // module name, which is declared in go.mod
+	FilePath               string    `json:"filePath"`               // file path for a concrete file or directory
 
 	Extra map[string]interface{} // extra data that passing accordingly
 }

--- a/pkg/dbclient/kusto.go
+++ b/pkg/dbclient/kusto.go
@@ -351,6 +351,13 @@ var basicCoverageMappings = []mapping{
 		},
 	},
 	{
+		Column:   "coverageWithIgnorance",
+		Datatype: "real",
+		Properties: properties{
+			Path: "$.coverageWithIgnorance",
+		},
+	},
+	{
 		Column:   "totalLines",
 		Datatype: "long",
 		Properties: properties{
@@ -376,6 +383,13 @@ var basicCoverageMappings = []mapping{
 		Datatype: "long",
 		Properties: properties{
 			Path: "$.coveredLines",
+		},
+	},
+	{
+		Column:   "coveredButIgnoredLines",
+		Datatype: "long",
+		Properties: properties{
+			Path: "$.coveredButIgnoredLines",
 		},
 	},
 	{

--- a/pkg/gocover/diffcover.go
+++ b/pkg/gocover/diffcover.go
@@ -204,7 +204,7 @@ func (diff *diffCover) generateStatistics() (*report.Statistics, error) {
 				section.Contents = append(section.Contents, fileContents[i-1])
 			}
 
-			var total, ignored, covered int
+			var total, ignored, covered, coveredButIgnored int
 			violated := false
 			changed := false
 			for _, st := range fun.Statements {
@@ -214,6 +214,10 @@ func (diff *diffCover) generateStatistics() (*report.Statistics, error) {
 
 				changed = true
 				total += 1
+
+				if st.Mode == parser.Ignore && st.Reached > 0 {
+					coveredButIgnored++
+				}
 
 				if st.Mode == parser.Ignore {
 					diff.logger.Debugf("%s ignore line %d", fun.File, st.StartLine)
@@ -243,6 +247,7 @@ func (diff *diffCover) generateStatistics() (*report.Statistics, error) {
 				coverProfile.CoveredLines += covered
 				coverProfile.TotalEffectiveLines += (total - ignored)
 				coverProfile.TotalIgnoredLines += ignored
+				coverProfile.CoveredButIgnoredLines += coveredButIgnored
 				if violated {
 					coverProfile.ViolationSections = append(coverProfile.ViolationSections, section)
 				}
@@ -262,6 +267,7 @@ func (diff *diffCover) generateStatistics() (*report.Statistics, error) {
 		node.TotalCoveredLines = int64(v.CoveredLines)
 		node.TotalEffectiveLines = int64(v.TotalEffectiveLines)
 		node.TotalIgnoredLines = int64(v.TotalIgnoredLines)
+		node.TotalCoveredButIgnoreLines = int64(v.CoveredButIgnoredLines)
 	}
 
 	diff.coverageTree.CollectCoverageData()

--- a/pkg/gocover/fullcover.go
+++ b/pkg/gocover/fullcover.go
@@ -172,12 +172,16 @@ func (full *fullCover) generateStatistics() (*report.Statistics, error) {
 
 			node := full.coverageTree.FindOrCreate(strings.TrimPrefix(fun.File, p.Root))
 
-			var total, ignored, covered int
+			var total, ignored, covered, coveredButIgnored int
 			violated := false
 			for _, st := range fun.Statements {
 				total += 1
 				node.TotalLines += 1
 
+				if st.Mode == parser.Ignore && st.Reached > 0 {
+					coveredButIgnored++
+					node.TotalCoveredButIgnoreLines += 1
+				}
 				if st.Mode == parser.Ignore {
 					full.logger.Debugf("%s ignore line %d", fun.File, st.StartLine)
 					ignored++
@@ -197,6 +201,7 @@ func (full *fullCover) generateStatistics() (*report.Statistics, error) {
 
 			coverProfile.TotalLines += total
 			coverProfile.CoveredLines += covered
+			coverProfile.CoveredButIgnoredLines += coveredButIgnored
 			coverProfile.TotalEffectiveLines += (total - ignored)
 			coverProfile.TotalIgnoredLines += ignored
 			coverProfile.TotalViolationLines = append(coverProfile.TotalViolationLines, section.ViolationLines...)

--- a/pkg/report/generator.go
+++ b/pkg/report/generator.go
@@ -177,13 +177,13 @@ func normalizeLines(lines int) string {
 	}
 }
 
-func percentCovered(total, covered int) float64 {
+func percentCovered(total, covered, coveredButIgnored int) float64 {
 	var c float64
 	// total is zero, no need to calculate
 	if total == 0 {
 		c = 100 // Avoid zero denominator.
 	} else {
-		c = float64(covered) / float64(total) * 100
+		c = float64(covered-coveredButIgnored) / float64(total) * 100
 	}
 	percent, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", c), 64)
 	return percent

--- a/pkg/report/generator_test.go
+++ b/pkg/report/generator_test.go
@@ -345,18 +345,20 @@ func TestNormalizeLines(t *testing.T) {
 func TestPercentCovered(t *testing.T) {
 	t.Run("percentCovered", func(t *testing.T) {
 		testsuites := []struct {
-			expected float64
-			total    int
-			covered  int
+			expected          float64
+			total             int
+			covered           int
+			coveredButIgnored int
 		}{
-			{expected: 100.0, total: 10, covered: 10},
-			{expected: 50.0, total: 10, covered: 5},
-			{expected: 0.0, total: 10, covered: 0},
-			{expected: 100.0, total: 0, covered: 0},
+			{expected: 100.0, total: 10, covered: 10, coveredButIgnored: 0},
+			{expected: 50.0, total: 10, covered: 5, coveredButIgnored: 0},
+			{expected: 0.0, total: 10, covered: 0, coveredButIgnored: 0},
+			{expected: 100.0, total: 0, covered: 0, coveredButIgnored: 0},
+			{expected: 10.0, total: 100, covered: 20, coveredButIgnored: 10},
 		}
 
 		for _, testcase := range testsuites {
-			actual := percentCovered(testcase.total, testcase.covered)
+			actual := percentCovered(testcase.total, testcase.covered, testcase.coveredButIgnored)
 			if testcase.expected != actual {
 				t.Errorf("expected %f, but get %f", testcase.expected, actual)
 			}

--- a/pkg/report/templates.go
+++ b/pkg/report/templates.go
@@ -76,7 +76,7 @@ var htmlCoverageReport = "" +
 
         <p>
             <b>Coverage </b> = Covered / Total <br />
-            <b>Coverage (with ignorance) </b> = Covered / Effective <br />
+            <b>Coverage (with ignorance) </b> = (Covered - CoveredButIngored) / Effective <br />
             <b>Total</b> = Effective + Ignored
         </p>
 
@@ -94,6 +94,7 @@ var htmlCoverageReport = "" +
                     {{ end }}
                     <th>Covered Lines</th>
                     <th>Ignored Lines</th>
+                    <th>Covered But Ignored Lines</th>
                     <th>Effective Lines</th>
                     <th>Total Lines</th>
                 </tr>
@@ -102,10 +103,11 @@ var htmlCoverageReport = "" +
                 {{ range .CoverageProfile }}
                 <tr>
                     <td><a href="#{{.FileName}}">{{ .FileName }}</a></td>
-                    <td>{{ PercentCovered .TotalEffectiveLines .CoveredLines }}</td>
-                    <td>{{ PercentCovered .TotalLines .CoveredLines }}</td>
+                    <td>{{ PercentCovered .TotalEffectiveLines .CoveredLines .CoveredButIgnoredLines }}</td>
+                    <td>{{ PercentCovered .TotalLines .CoveredLines 0 }}</td>
                     <td>{{ .CoveredLines }}</td>
                     <td>{{ .TotalIgnoredLines }}</td>
+                    <td>{{ .CoveredButIgnoredLines }}</td>
                     <td>{{ .TotalEffectiveLines }}</td>
                     <td>{{ .TotalLines }}</td>
                 </tr>
@@ -115,7 +117,7 @@ var htmlCoverageReport = "" +
 
         {{ range .CoverageProfile }}
             <div class="src-snippet">
-                {{ if lt (PercentCovered .TotalEffectiveLines .CoveredLines) 100.0 }}
+                {{ if lt (PercentCovered .TotalEffectiveLines .CoveredLines .CoveredButIgnoredLines) 100.0 }}
                 <div class="src-name" id="{{.FileName}}">{{ .FileName }}</div>
                 <div class="snippets">
                     {{range .CodeSnippet}}

--- a/pkg/report/tree_test.go
+++ b/pkg/report/tree_test.go
@@ -20,25 +20,27 @@ func beforeRun() {
 				Name: "child1",
 				Nodes: map[string]*TreeNode{
 					"leaf1": {
-						Name:                "leaf1",
-						TotalLines:          120,
-						TotalEffectiveLines: 100,
-						TotalIgnoredLines:   20,
-						TotalCoveredLines:   80,
-						TotalViolationLines: 20,
-						isLeaf:              true,
+						Name:                       "leaf1",
+						TotalLines:                 120,
+						TotalEffectiveLines:        100,
+						TotalIgnoredLines:          20,
+						TotalCoveredLines:          80,
+						TotalViolationLines:        20,
+						TotalCoveredButIgnoreLines: 1,
+						isLeaf:                     true,
 					},
 					"child3": {
 						Name: "child3",
 						Nodes: map[string]*TreeNode{
 							"leaf3": {
-								Name:                "leaf3",
-								TotalLines:          110,
-								TotalEffectiveLines: 80,
-								TotalIgnoredLines:   30,
-								TotalCoveredLines:   50,
-								TotalViolationLines: 30,
-								isLeaf:              true,
+								Name:                       "leaf3",
+								TotalLines:                 110,
+								TotalEffectiveLines:        80,
+								TotalIgnoredLines:          30,
+								TotalCoveredLines:          50,
+								TotalViolationLines:        30,
+								TotalCoveredButIgnoreLines: 2,
+								isLeaf:                     true,
 							},
 						},
 					},
@@ -48,22 +50,24 @@ func beforeRun() {
 				Name: "child2",
 				Nodes: map[string]*TreeNode{
 					"leaf20": {
-						Name:                "leaf20",
-						TotalLines:          60,
-						TotalEffectiveLines: 50,
-						TotalIgnoredLines:   10,
-						TotalCoveredLines:   40,
-						TotalViolationLines: 10,
-						isLeaf:              true,
+						Name:                       "leaf20",
+						TotalLines:                 60,
+						TotalEffectiveLines:        50,
+						TotalIgnoredLines:          10,
+						TotalCoveredLines:          40,
+						TotalViolationLines:        10,
+						TotalCoveredButIgnoreLines: 3,
+						isLeaf:                     true,
 					},
 					"leaf21": {
-						Name:                "leaf21",
-						TotalLines:          90,
-						TotalEffectiveLines: 60,
-						TotalIgnoredLines:   30,
-						TotalCoveredLines:   30,
-						TotalViolationLines: 30,
-						isLeaf:              true,
+						Name:                       "leaf21",
+						TotalLines:                 90,
+						TotalEffectiveLines:        60,
+						TotalIgnoredLines:          30,
+						TotalCoveredLines:          30,
+						TotalViolationLines:        30,
+						TotalCoveredButIgnoreLines: 4,
+						isLeaf:                     true,
 					},
 				},
 			},
@@ -75,7 +79,7 @@ func TestCoverageTree(t *testing.T) {
 
 	t.Run("collect when root is nil", func(t *testing.T) {
 		var root *TreeNode
-		total, effectived, ignored, covered, violation := collect(root)
+		total, effectived, ignored, covered, violation, coveredButIgnored := collect(root)
 		if total != 0 {
 			t.Errorf("total expected 0, but get %d", total)
 		}
@@ -91,12 +95,15 @@ func TestCoverageTree(t *testing.T) {
 		if violation != 0 {
 			t.Errorf("violation expected 0, but get %d", violation)
 		}
+		if coveredButIgnored != 0 {
+			t.Errorf("coveredButIgnored expected 0, but get %d", coveredButIgnored)
+		}
 	})
 
 	t.Run("collect when root contains all the statistical data", func(t *testing.T) {
 		beforeRun()
 
-		total, effectived, ignored, covered, violation := collect(root)
+		total, effectived, ignored, covered, violation, coveredButIgnored := collect(root)
 		if total != 380 {
 			t.Errorf("total expected 380, but get %d", total)
 		}
@@ -111,6 +118,9 @@ func TestCoverageTree(t *testing.T) {
 		}
 		if violation != 90 {
 			t.Errorf("violation expected 90, but get %d", violation)
+		}
+		if coveredButIgnored != 10 {
+			t.Errorf("coveredButIgnored expected 0, but get %d", coveredButIgnored)
 		}
 	})
 
@@ -158,6 +168,9 @@ func TestCoverageTree(t *testing.T) {
 		}
 		if coverageTree.Root.TotalViolationLines != 90 {
 			t.Errorf("violation expected 90, but get %d", coverageTree.Root.TotalViolationLines)
+		}
+		if coverageTree.Root.TotalCoveredButIgnoreLines != 10 {
+			t.Errorf("coveredButIgnored expected 90, but get %d", coverageTree.Root.TotalCoveredButIgnoreLines)
 		}
 	})
 

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -24,6 +24,8 @@ type Statistics struct {
 	TotalIgnoredLines int
 	// TotalCoveredLines indicates total covered lines that count for coverage.
 	TotalCoveredLines int
+	// CoveredButIgnoredLines indicates the lines that covered but ignored.
+	TotalCoveredButIgnoredLines int
 	// TotalViolationLines represents all the lines that miss test coverage.
 	TotalViolationLines int
 	// TotalCoveragePercent represents the coverage percent for current diff.
@@ -50,6 +52,8 @@ type CoverageProfile struct {
 	TotalIgnoredLines int
 	// CoveredLines indicates covered lines of this coverage profile.
 	CoveredLines int
+	// CoveredButIgnoredLines indicates the lines that covered but ignored.
+	CoveredButIgnoredLines int
 	// CoveragePercent indicates the diff coverage percent for this file.
 	TotalViolationLines []int
 	// ViolationSections indicates the violation sections that miss full coverage.


### PR DESCRIPTION
For covered code lines, it may ignore with ignore annotation. For the code lines like these, they should not be token account into the calculation of coverage result.

The logic of coverage is:

TotalLines = TotalEffectiveLines + TotalIgnoredLines
TotalCoveredLines = TotalCoveredButNotIgnoredLines + TotalCoveredButIgnoredLines

Results:
Coverage = TotalCoveredLines / TotalLines
CoverageWithIgnorance = TotalCoveredButNotIgnoredLines / TotalEffectiveLines = (TotalCoveredLines - TotalCoveredButIgnoredLines) / TotalEffectiveLines
