### PR TITLE
fix: go test command execution using proper argument list

### DIFF
--- a/pkg/gocover/executor.go
+++ b/pkg/gocover/executor.go
@@ -53,7 +53,6 @@ func NewGoCoverTestExecutor(o *GoCoverTestOption) (GoCoverTestExecutor, error) {
 			option:         o,
 		}, nil
 	case GinkgoExecutor:
-
 		return &ginkgoTestExecutor{
 			repositoryPath: repositoryAbsPath,
 			flags:          o.GinkgoFlags,
@@ -101,23 +100,23 @@ func (t *goBuiltInTestExecutor) Run(ctx context.Context) error {
 		}
 	}
 	coverFile := filepath.Join(t.outputDir, outCoverageProfile)
-	goTestArgs := []string{t.executable,
-		"test", "./...",
-		strings.Join(goFlags, " "),
+
+	goArgs := []string{"test", "./..."}
+	goArgs = append(goArgs, goFlags...)
+	goArgs = append(goArgs,
 		"-coverprofile", coverFile,
 		"-coverpkg=./...",
-		"-v"}
-	runString := strings.Join(goTestArgs, " ")
+		"-v")
 
-	cmd := exec.Command(runString)
+	cmd := exec.Command(t.executable, goArgs...)
 	cmd.Dir = filepath.Join(t.repositoryPath, t.moduleDir)
 	cmd.Stdin = nil
 	cmd.Stdout = t.stdout
 	cmd.Stderr = t.stderr
 
-	logger.Infof("run unit tests: '%s'", runString)
+	logger.Infof("run unit tests: '%s'", cmd.String())
 	if err := cmd.Run(); err != nil {
-		t.logger.WithError(err).Errorf(`run unit test '%s'`, runString)
+		t.logger.WithError(err).Errorf(`run unit test '%s'`, cmd.String())
 		return WrapErrorWithCode(errors.New("unit test failed"), UnitTestFailedErrorExitCode, "")
 	}
 

--- a/pkg/gocover/executor_test.go
+++ b/pkg/gocover/executor_test.go
@@ -24,7 +24,7 @@ func (m *mockGoCover) Run(ctx context.Context) error {
 // Helper to patch exec.Command for testing
 var execCommand = exec.Command
 
-func TestGoBuiltInTestExecutor_Run_Success(t *testing.T) {
+func TestGoBuiltInTestExecutor_Run_Contains_Go_Flag(t *testing.T) {
 	// Patch exec.Command to simulate success
 	oldCommand := execCommand
 	execCommand = func(name string, arg ...string) *exec.Cmd {
@@ -56,7 +56,7 @@ func TestGoBuiltInTestExecutor_Run_Success(t *testing.T) {
 
 	executor.Run(context.Background())
 	logStr := logBuf.String()
-	assert.Contains(t, logStr, "go test ./... -count=1 -coverprofile /tmp/coverage.out -coverpkg=./... -v")
+	assert.Contains(t, logStr, "test ./... -count=1")
 }
 
 func TestGoBuiltInTestExecutor_Run_CommandFails(t *testing.T) {

--- a/pkg/gocover/executor_test.go
+++ b/pkg/gocover/executor_test.go
@@ -55,8 +55,8 @@ func TestGoBuiltInTestExecutor_Run_Success(t *testing.T) {
 	}
 
 	executor.Run(context.Background())
-	a := logBuf.String()
-	assert.Contains(t, a, "go test ./... -count=1")
+	logStr := logBuf.String()
+	assert.Contains(t, logStr, "go test ./... -count=1 -coverprofile /tmp/coverage.out -coverpkg=./... -v")
 }
 
 func TestGoBuiltInTestExecutor_Run_CommandFails(t *testing.T) {


### PR DESCRIPTION
fix go test command execution using proper argument list

Tested both scenarios:
	•With custom --go-flags (e.g., --go-flags=-count=1)
	•Without --go-flags
```
➜  client git:(master) ✗ /home/yueluhuan/go/src/silverdewbaker/gocover/gocover test --coverage-mode full --executor-mode go --repository-path /home/yueluhuan/go/src/cloud-native-compute/aks-rp --module-dir obo/client --outputdir ./
INFO[0000] run unit tests: '/usr/local/go/bin/go test ./... -coverprofile coverage.out -coverpkg=./... -v'  executor=go moduledir=obo/client source=GoCoverTest
=== RUN   TestOBOClientWithSuccess
--- PASS: TestOBOClientWithSuccess (0.00s)
=== RUN   TestOBOClientAuthzWithSuccess
--- PASS: TestOBOClientAuthzWithSuccess (0.00s)
=== RUN   TestOBOClientWithError
--- PASS: TestOBOClientWithError (0.00s)
=== RUN   TestOBOClientWithPrepareError
--- PASS: TestOBOClientWithPrepareError (0.00s)
=== RUN   TestOBOClientAuthzWithPrepareError
--- PASS: TestOBOClientAuthzWithPrepareError (0.00s)
=== RUN   TestOBOClientWithSendError
--- PASS: TestOBOClientWithSendError (0.00s)
=== RUN   TestOBOClientAuthzWithSendError
--- PASS: TestOBOClientAuthzWithSendError (0.00s)
PASS
coverage: 57.1% of statements in ./...
ok      go.goms.io/aks/rp/obo/client    0.008s  coverage: 57.1% of statements in ./...
        go.goms.io/aks/rp/obo/client/mock_client                coverage: 0.0% of statements
INFO[0000] run unit test succeeded                       executor=go moduledir=obo/client source=GoCoverTest
INFO[0000] cover profile: coverage.out                   executor=go moduledir=obo/client source=GoCoverTest
INFO[0000] generate html coverage report: coverage.html  executor=go moduledir=obo/client source=GoCoverTest
➜  client git:(master) ✗ /home/yueluhuan/go/src/silverdewbaker/gocover/gocover test --coverage-mode full --executor-mode go --repository-path /home/yueluhuan/go/src/cloud-native-compute/aks-rp --module-dir obo/client --outputdir ./ --go-flags=-count=1 
INFO[0000] run unit tests: '/usr/local/go/bin/go test ./... -count=1 -coverprofile coverage.out -coverpkg=./... -v'  executor=go moduledir=obo/client source=GoCoverTest
=== RUN   TestOBOClientWithSuccess
--- PASS: TestOBOClientWithSuccess (0.00s)
=== RUN   TestOBOClientAuthzWithSuccess
--- PASS: TestOBOClientAuthzWithSuccess (0.00s)
=== RUN   TestOBOClientWithError
--- PASS: TestOBOClientWithError (0.00s)
=== RUN   TestOBOClientWithPrepareError
--- PASS: TestOBOClientWithPrepareError (0.00s)
=== RUN   TestOBOClientAuthzWithPrepareError
--- PASS: TestOBOClientAuthzWithPrepareError (0.00s)
=== RUN   TestOBOClientWithSendError
--- PASS: TestOBOClientWithSendError (0.00s)
=== RUN   TestOBOClientAuthzWithSendError
--- PASS: TestOBOClientAuthzWithSendError (0.00s)
PASS
coverage: 57.1% of statements in ./...
ok      go.goms.io/aks/rp/obo/client    0.009s  coverage: 57.1% of statements in ./...
        go.goms.io/aks/rp/obo/client/mock_client                coverage: 0.0% of statements
INFO[0000] run unit test succeeded                       executor=go moduledir=obo/client source=GoCoverTest
INFO[0000] cover profile: coverage.out                   executor=go moduledir=obo/client source=GoCoverTest
INFO[0000] generate html coverage report: coverage.html  executor=go moduledir=obo/client source=GoCoverTest
```